### PR TITLE
fix: port c4 to gas-service-v2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -108,7 +108,7 @@ unexpected_cfgs = { level = "warn", check-cfg = [
 
 
 [workspace.dependencies]
-anchor-lang = { version = "0.31.1", features = ["event-cpi", "idl-build"] }
+anchor-lang = { version = "0.31.1", features = ["event-cpi"] }
 anchor-spl = "0.31.1"
 alloy-primitives = "0.7"
 alloy-sol-types = "0.7"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -108,7 +108,7 @@ unexpected_cfgs = { level = "warn", check-cfg = [
 
 
 [workspace.dependencies]
-anchor-lang = { version = "0.31.1", features = ["event-cpi"] }
+anchor-lang = { version = "0.31.1", features = ["event-cpi", "idl-build"] }
 anchor-spl = "0.31.1"
 alloy-primitives = "0.7"
 alloy-sol-types = "0.7"

--- a/crates/axelar-solana-gas-service-events/src/events.rs
+++ b/crates/axelar-solana-gas-service-events/src/events.rs
@@ -1,7 +1,7 @@
 //! Events emitted by the Axelar Solana Gas service
 
 use anchor_lang::prelude::{
-    borsh, event, AnchorDeserialize, AnchorSerialize, Discriminator, Pubkey,
+    borsh, event, AnchorDeserialize, AnchorSerialize, Discriminator, IdlBuild, Pubkey,
 };
 
 use event_utils::{read_array, read_string, read_u64, EventParseError};

--- a/crates/axelar-solana-gas-service-events/src/events.rs
+++ b/crates/axelar-solana-gas-service-events/src/events.rs
@@ -27,8 +27,8 @@ pub enum GasServiceEvent {
 #[event]
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub struct NativeGasPaidForContractCallEvent {
-    /// The Gas service config PDA
-    pub config_pda: Pubkey,
+    /// The Gas service treasury PDA
+    pub treasury: Pubkey,
     /// Destination chain on the Axelar network
     pub destination_chain: String,
     /// Destination address on the Axelar network
@@ -49,10 +49,10 @@ impl NativeGasPaidForContractCallEvent {
     /// # Errors
     /// - if the data could not be parsed into an event
     pub fn new<I: Iterator<Item = Vec<u8>>>(mut data: I) -> Result<Self, EventParseError> {
-        let config_pda_data = data
+        let treasury_data = data
             .next()
-            .ok_or(EventParseError::MissingData("config_pda"))?;
-        let config_pda = Pubkey::new_from_array(read_array::<32>("config_pda", &config_pda_data)?);
+            .ok_or(EventParseError::MissingData("treasury"))?;
+        let treasury = Pubkey::new_from_array(read_array::<32>("treasury", &treasury_data)?);
 
         let destination_chain_data = data
             .next()
@@ -83,7 +83,7 @@ impl NativeGasPaidForContractCallEvent {
         let gas_fee_amount = read_u64("gas_fee_amount", &gas_fee_amount_data)?;
 
         Ok(Self {
-            config_pda,
+            treasury,
             destination_chain,
             destination_address,
             payload_hash,
@@ -98,8 +98,8 @@ impl NativeGasPaidForContractCallEvent {
 #[event]
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub struct NativeGasAddedEvent {
-    /// The Gas service config PDA
-    pub config_pda: Pubkey,
+    /// The Gas service treasury PDA
+    pub treasury: Pubkey,
     /// Solana transaction signature
     pub tx_hash: [u8; 64],
     /// index of the log
@@ -116,10 +116,10 @@ impl NativeGasAddedEvent {
     /// # Errors
     /// - if the data could not be parsed into an event
     pub fn new<I: Iterator<Item = Vec<u8>>>(mut data: I) -> Result<Self, EventParseError> {
-        let config_pda_data = data
+        let treasury_data = data
             .next()
-            .ok_or(EventParseError::MissingData("config_pda"))?;
-        let config_pda = Pubkey::new_from_array(read_array::<32>("config_pda", &config_pda_data)?);
+            .ok_or(EventParseError::MissingData("treasury"))?;
+        let treasury = Pubkey::new_from_array(read_array::<32>("treasury", &treasury_data)?);
 
         let tx_hash_data = data.next().ok_or(EventParseError::MissingData("tx_hash"))?;
         let tx_hash = read_array::<64>("tx_hash", &tx_hash_data)?;
@@ -141,7 +141,7 @@ impl NativeGasAddedEvent {
         let gas_fee_amount = read_u64("gas_fee_amount", &gas_fee_amount_data)?;
 
         Ok(Self {
-            config_pda,
+            treasury,
             tx_hash,
             log_index,
             refund_address,
@@ -156,8 +156,8 @@ impl NativeGasAddedEvent {
 pub struct NativeGasRefundedEvent {
     /// Solana transaction signature
     pub tx_hash: [u8; 64],
-    /// The Gas service config PDA
-    pub config_pda: Pubkey,
+    /// The Gas service treasury PDA
+    pub treasury: Pubkey,
     /// The log index
     pub log_index: u64,
     /// The receiver of the refund
@@ -175,10 +175,10 @@ impl NativeGasRefundedEvent {
         let tx_hash_data = data.next().ok_or(EventParseError::MissingData("tx_hash"))?;
         let tx_hash = read_array::<64>("tx_hash", &tx_hash_data)?;
 
-        let config_pda_data = data
+        let treasury_data = data
             .next()
-            .ok_or(EventParseError::MissingData("config_pda"))?;
-        let config_pda = Pubkey::new_from_array(read_array::<32>("config_pda", &config_pda_data)?);
+            .ok_or(EventParseError::MissingData("treasury"))?;
+        let treasury = Pubkey::new_from_array(read_array::<32>("treasury", &treasury_data)?);
 
         let log_index_data = data
             .next()
@@ -195,7 +195,7 @@ impl NativeGasRefundedEvent {
 
         Ok(Self {
             tx_hash,
-            config_pda,
+            treasury,
             log_index,
             receiver,
             fees,
@@ -207,8 +207,8 @@ impl NativeGasRefundedEvent {
 #[event]
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub struct SplGasPaidForContractCallEvent {
-    /// The Gas service config PDA
-    pub config_pda: Pubkey,
+    /// The Gas service treasury PDA
+    pub treasury: Pubkey,
     /// The Gas service config associated token account PDA
     pub config_pda_token_account: Pubkey,
     /// Mint of the token
@@ -235,10 +235,10 @@ impl SplGasPaidForContractCallEvent {
     /// # Errors
     /// - if the data could not be parsed into an event
     pub fn new<I: Iterator<Item = Vec<u8>>>(mut data: I) -> Result<Self, EventParseError> {
-        let config_pda_data = data
+        let treasury_data = data
             .next()
-            .ok_or(EventParseError::MissingData("config_pda"))?;
-        let config_pda = Pubkey::new_from_array(read_array::<32>("config_pda", &config_pda_data)?);
+            .ok_or(EventParseError::MissingData("treasury"))?;
+        let treasury = Pubkey::new_from_array(read_array::<32>("treasury", &treasury_data)?);
 
         let config_pda_token_account = data
             .next()
@@ -286,7 +286,7 @@ impl SplGasPaidForContractCallEvent {
         let gas_fee_amount = read_u64("gas_fee_amount", &gas_fee_amount_data)?;
 
         Ok(Self {
-            config_pda,
+            treasury,
             config_pda_token_account,
             mint,
             token_program_id,
@@ -304,8 +304,8 @@ impl SplGasPaidForContractCallEvent {
 #[event]
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub struct SplGasAddedEvent {
-    /// The Gas service config PDA
-    pub config_pda: Pubkey,
+    /// The Gas service treasury PDA
+    pub treasury: Pubkey,
     /// The Gas service config associated token account PDA
     pub config_pda_token_account: Pubkey,
     /// Mint of the token
@@ -328,10 +328,10 @@ impl SplGasAddedEvent {
     /// # Errors
     /// - if the data could not be parsed into an event
     pub fn new<I: Iterator<Item = Vec<u8>>>(mut data: I) -> Result<Self, EventParseError> {
-        let config_pda = data
+        let treasury_data = data
             .next()
-            .ok_or(EventParseError::MissingData("config_pda"))?;
-        let config_pda = Pubkey::new_from_array(read_array::<32>("config_pda", &config_pda)?);
+            .ok_or(EventParseError::MissingData("treasury"))?;
+        let treasury = Pubkey::new_from_array(read_array::<32>("treasury", &treasury_data)?);
 
         let config_pda_token_account = data
             .next()
@@ -370,7 +370,7 @@ impl SplGasAddedEvent {
         let gas_fee_amount = read_u64("gas_fee_amount", &gas_fee_amount_data)?;
 
         Ok(Self {
-            config_pda,
+            treasury,
             config_pda_token_account,
             mint,
             token_program_id,
@@ -394,8 +394,8 @@ pub struct SplGasRefundedEvent {
     pub token_program_id: Pubkey,
     /// Solana transaction signature
     pub tx_hash: [u8; 64],
-    /// The Gas service config PDA
-    pub config_pda: Pubkey,
+    /// The Gas service treasury PDA
+    pub treasury: Pubkey,
     /// The log index
     pub log_index: u64,
     /// The receiver of the refund
@@ -413,10 +413,10 @@ impl SplGasRefundedEvent {
         let tx_hash_data = data.next().ok_or(EventParseError::MissingData("tx_hash"))?;
         let tx_hash = read_array::<64>("tx_hash", &tx_hash_data)?;
 
-        let config_pda_data = data
+        let treasury_data = data
             .next()
-            .ok_or(EventParseError::MissingData("config_pda"))?;
-        let config_pda = Pubkey::new_from_array(read_array::<32>("config_pda", &config_pda_data)?);
+            .ok_or(EventParseError::MissingData("treasury"))?;
+        let treasury = Pubkey::new_from_array(read_array::<32>("treasury", &treasury_data)?);
 
         let config_pda_token_account = data
             .next()
@@ -453,7 +453,7 @@ impl SplGasRefundedEvent {
             mint,
             token_program_id,
             tx_hash,
-            config_pda,
+            treasury,
             log_index,
             receiver,
             fees,

--- a/crates/axelar-solana-gas-service-events/src/events.rs
+++ b/crates/axelar-solana-gas-service-events/src/events.rs
@@ -210,7 +210,7 @@ pub struct SplGasPaidForContractCallEvent {
     /// The Gas service config PDA
     pub config_pda: Pubkey,
     /// The Gas service config associated token account PDA
-    pub config_pda_ata: Pubkey,
+    pub config_pda_token_account: Pubkey,
     /// Mint of the token
     pub mint: Pubkey,
     /// The token program id
@@ -240,11 +240,11 @@ impl SplGasPaidForContractCallEvent {
             .ok_or(EventParseError::MissingData("config_pda"))?;
         let config_pda = Pubkey::new_from_array(read_array::<32>("config_pda", &config_pda_data)?);
 
-        let config_pda_ata = data
+        let config_pda_token_account = data
             .next()
-            .ok_or(EventParseError::MissingData("config_pda_ata"))?;
-        let config_pda_ata =
-            Pubkey::new_from_array(read_array::<32>("config_pda_ata", &config_pda_ata)?);
+            .ok_or(EventParseError::MissingData("config_pda_token_account"))?;
+        let config_pda_token_account =
+            Pubkey::new_from_array(read_array::<32>("config_pda_token_account", &config_pda_token_account)?);
 
         let mint = data.next().ok_or(EventParseError::MissingData("mint"))?;
         let mint = Pubkey::new_from_array(read_array::<32>("mint", &mint)?);
@@ -285,7 +285,7 @@ impl SplGasPaidForContractCallEvent {
 
         Ok(Self {
             config_pda,
-            config_pda_ata,
+            config_pda_token_account,
             mint,
             token_program_id,
             destination_chain,
@@ -305,7 +305,7 @@ pub struct SplGasAddedEvent {
     /// The Gas service config PDA
     pub config_pda: Pubkey,
     /// The Gas service config associated token account PDA
-    pub config_pda_ata: Pubkey,
+    pub config_pda_token_account: Pubkey,
     /// Mint of the token
     pub mint: Pubkey,
     /// The token program id
@@ -331,11 +331,11 @@ impl SplGasAddedEvent {
             .ok_or(EventParseError::MissingData("config_pda"))?;
         let config_pda = Pubkey::new_from_array(read_array::<32>("config_pda", &config_pda)?);
 
-        let config_pda_ata = data
+        let config_pda_token_account = data
             .next()
-            .ok_or(EventParseError::MissingData("config_pda_ata"))?;
-        let config_pda_ata =
-            Pubkey::new_from_array(read_array::<32>("config_pda_ata", &config_pda_ata)?);
+            .ok_or(EventParseError::MissingData("config_pda_token_account"))?;
+        let config_pda_token_account =
+            Pubkey::new_from_array(read_array::<32>("config_pda_token_account", &config_pda_token_account)?);
 
         let mint = data.next().ok_or(EventParseError::MissingData("mint"))?;
         let mint = Pubkey::new_from_array(read_array::<32>("mint", &mint)?);
@@ -367,7 +367,7 @@ impl SplGasAddedEvent {
 
         Ok(Self {
             config_pda,
-            config_pda_ata,
+            config_pda_token_account,
             mint,
             token_program_id,
             tx_hash,
@@ -383,7 +383,7 @@ impl SplGasAddedEvent {
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub struct SplGasRefundedEvent {
     /// The Gas service config associated token account PDA
-    pub config_pda_ata: Pubkey,
+    pub config_pda_token_account: Pubkey,
     /// Mint of the token
     pub mint: Pubkey,
     /// The token program id
@@ -414,11 +414,11 @@ impl SplGasRefundedEvent {
             .ok_or(EventParseError::MissingData("config_pda"))?;
         let config_pda = Pubkey::new_from_array(read_array::<32>("config_pda", &config_pda_data)?);
 
-        let config_pda_ata = data
+        let config_pda_token_account = data
             .next()
-            .ok_or(EventParseError::MissingData("config_pda_ata"))?;
-        let config_pda_ata =
-            Pubkey::new_from_array(read_array::<32>("config_pda_ata", &config_pda_ata)?);
+            .ok_or(EventParseError::MissingData("config_pda_token_account"))?;
+        let config_pda_token_account =
+            Pubkey::new_from_array(read_array::<32>("config_pda_token_account", &config_pda_token_account)?);
 
         let mint = data.next().ok_or(EventParseError::MissingData("mint"))?;
         let mint = Pubkey::new_from_array(read_array::<32>("mint", &mint)?);
@@ -443,7 +443,7 @@ impl SplGasRefundedEvent {
         let fees = read_u64("fees", &fees_data)?;
 
         Ok(Self {
-            config_pda_ata,
+            config_pda_token_account,
             mint,
             token_program_id,
             tx_hash,

--- a/crates/axelar-solana-gas-service-events/src/events.rs
+++ b/crates/axelar-solana-gas-service-events/src/events.rs
@@ -1,7 +1,7 @@
 //! Events emitted by the Axelar Solana Gas service
 
 use anchor_lang::prelude::{
-    borsh, event, AnchorDeserialize, AnchorSerialize, Discriminator, IdlBuild, Pubkey,
+    borsh, event, AnchorDeserialize, AnchorSerialize, Discriminator, Pubkey,
 };
 
 use event_utils::{read_array, read_string, read_u64, EventParseError};
@@ -243,8 +243,10 @@ impl SplGasPaidForContractCallEvent {
         let config_pda_token_account = data
             .next()
             .ok_or(EventParseError::MissingData("config_pda_token_account"))?;
-        let config_pda_token_account =
-            Pubkey::new_from_array(read_array::<32>("config_pda_token_account", &config_pda_token_account)?);
+        let config_pda_token_account = Pubkey::new_from_array(read_array::<32>(
+            "config_pda_token_account",
+            &config_pda_token_account,
+        )?);
 
         let mint = data.next().ok_or(EventParseError::MissingData("mint"))?;
         let mint = Pubkey::new_from_array(read_array::<32>("mint", &mint)?);
@@ -334,8 +336,10 @@ impl SplGasAddedEvent {
         let config_pda_token_account = data
             .next()
             .ok_or(EventParseError::MissingData("config_pda_token_account"))?;
-        let config_pda_token_account =
-            Pubkey::new_from_array(read_array::<32>("config_pda_token_account", &config_pda_token_account)?);
+        let config_pda_token_account = Pubkey::new_from_array(read_array::<32>(
+            "config_pda_token_account",
+            &config_pda_token_account,
+        )?);
 
         let mint = data.next().ok_or(EventParseError::MissingData("mint"))?;
         let mint = Pubkey::new_from_array(read_array::<32>("mint", &mint)?);
@@ -417,8 +421,10 @@ impl SplGasRefundedEvent {
         let config_pda_token_account = data
             .next()
             .ok_or(EventParseError::MissingData("config_pda_token_account"))?;
-        let config_pda_token_account =
-            Pubkey::new_from_array(read_array::<32>("config_pda_token_account", &config_pda_token_account)?);
+        let config_pda_token_account = Pubkey::new_from_array(read_array::<32>(
+            "config_pda_token_account",
+            &config_pda_token_account,
+        )?);
 
         let mint = data.next().ok_or(EventParseError::MissingData("mint"))?;
         let mint = Pubkey::new_from_array(read_array::<32>("mint", &mint)?);

--- a/crates/axelar-solana-gas-service-events/src/events.rs
+++ b/crates/axelar-solana-gas-service-events/src/events.rs
@@ -209,8 +209,8 @@ impl NativeGasRefundedEvent {
 pub struct SplGasPaidForContractCallEvent {
     /// The Gas service treasury PDA
     pub treasury: Pubkey,
-    /// The Gas service config associated token account PDA
-    pub config_pda_token_account: Pubkey,
+    /// The Gas service treasury token account PDA
+    pub treasury_token_account: Pubkey,
     /// Mint of the token
     pub mint: Pubkey,
     /// The token program id
@@ -240,12 +240,12 @@ impl SplGasPaidForContractCallEvent {
             .ok_or(EventParseError::MissingData("treasury"))?;
         let treasury = Pubkey::new_from_array(read_array::<32>("treasury", &treasury_data)?);
 
-        let config_pda_token_account = data
+        let treasury_token_account = data
             .next()
-            .ok_or(EventParseError::MissingData("config_pda_token_account"))?;
-        let config_pda_token_account = Pubkey::new_from_array(read_array::<32>(
-            "config_pda_token_account",
-            &config_pda_token_account,
+            .ok_or(EventParseError::MissingData("treasury_token_account"))?;
+        let treasury_token_account = Pubkey::new_from_array(read_array::<32>(
+            "treasury_token_account",
+            &treasury_token_account,
         )?);
 
         let mint = data.next().ok_or(EventParseError::MissingData("mint"))?;
@@ -287,7 +287,7 @@ impl SplGasPaidForContractCallEvent {
 
         Ok(Self {
             treasury,
-            config_pda_token_account,
+            treasury_token_account,
             mint,
             token_program_id,
             destination_chain,
@@ -306,8 +306,8 @@ impl SplGasPaidForContractCallEvent {
 pub struct SplGasAddedEvent {
     /// The Gas service treasury PDA
     pub treasury: Pubkey,
-    /// The Gas service config associated token account PDA
-    pub config_pda_token_account: Pubkey,
+    /// The Gas service treasury token account PDA
+    pub treasury_token_account: Pubkey,
     /// Mint of the token
     pub mint: Pubkey,
     /// The token program id
@@ -333,12 +333,12 @@ impl SplGasAddedEvent {
             .ok_or(EventParseError::MissingData("treasury"))?;
         let treasury = Pubkey::new_from_array(read_array::<32>("treasury", &treasury_data)?);
 
-        let config_pda_token_account = data
+        let treasury_token_account = data
             .next()
-            .ok_or(EventParseError::MissingData("config_pda_token_account"))?;
-        let config_pda_token_account = Pubkey::new_from_array(read_array::<32>(
-            "config_pda_token_account",
-            &config_pda_token_account,
+            .ok_or(EventParseError::MissingData("treasury_token_account"))?;
+        let treasury_token_account = Pubkey::new_from_array(read_array::<32>(
+            "treasury_token_account",
+            &treasury_token_account,
         )?);
 
         let mint = data.next().ok_or(EventParseError::MissingData("mint"))?;
@@ -371,7 +371,7 @@ impl SplGasAddedEvent {
 
         Ok(Self {
             treasury,
-            config_pda_token_account,
+            treasury_token_account,
             mint,
             token_program_id,
             tx_hash,
@@ -386,8 +386,8 @@ impl SplGasAddedEvent {
 #[event]
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub struct SplGasRefundedEvent {
-    /// The Gas service config associated token account PDA
-    pub config_pda_token_account: Pubkey,
+    /// The Gas service treasury token account PDA
+    pub treasury_token_account: Pubkey,
     /// Mint of the token
     pub mint: Pubkey,
     /// The token program id
@@ -418,12 +418,12 @@ impl SplGasRefundedEvent {
             .ok_or(EventParseError::MissingData("treasury"))?;
         let treasury = Pubkey::new_from_array(read_array::<32>("treasury", &treasury_data)?);
 
-        let config_pda_token_account = data
+        let treasury_token_account = data
             .next()
-            .ok_or(EventParseError::MissingData("config_pda_token_account"))?;
-        let config_pda_token_account = Pubkey::new_from_array(read_array::<32>(
-            "config_pda_token_account",
-            &config_pda_token_account,
+            .ok_or(EventParseError::MissingData("treasury_token_account"))?;
+        let treasury_token_account = Pubkey::new_from_array(read_array::<32>(
+            "treasury_token_account",
+            &treasury_token_account,
         )?);
 
         let mint = data.next().ok_or(EventParseError::MissingData("mint"))?;
@@ -449,7 +449,7 @@ impl SplGasRefundedEvent {
         let fees = read_u64("fees", &fees_data)?;
 
         Ok(Self {
-            config_pda_token_account,
+            treasury_token_account,
             mint,
             token_program_id,
             tx_hash,

--- a/crates/gateway-event-stack/src/lib.rs
+++ b/crates/gateway-event-stack/src/lib.rs
@@ -432,7 +432,7 @@ mod tests {
         let result = build_program_event_stack(&match_context, &logs, parse_gas_service_log);
 
         let event = NativeGasPaidForContractCallEvent {
-            config_pda: "DR9Ja5ojPLPDWmWFRmpc2SEUvK94dKX4uM6AofgwAAJm"
+            treasury: "DR9Ja5ojPLPDWmWFRmpc2SEUvK94dKX4uM6AofgwAAJm"
                 .parse()
                 .unwrap(),
             destination_chain: "evm".to_owned(),

--- a/programs/axelar-solana-gas-service-v2/src/instructions/add_native_gas.rs
+++ b/programs/axelar-solana-gas-service-v2/src/instructions/add_native_gas.rs
@@ -47,7 +47,7 @@ pub fn add_native_gas(
     )?;
 
     emit_cpi!(NativeGasAddedEvent {
-        config_pda: *treasury_account_info.key,
+        treasury: *treasury_account_info.key,
         tx_hash,
         log_index,
         refund_address,

--- a/programs/axelar-solana-gas-service-v2/src/instructions/add_spl_gas.rs
+++ b/programs/axelar-solana-gas-service-v2/src/instructions/add_spl_gas.rs
@@ -24,7 +24,7 @@ pub struct AddSplGas<'info> {
         associated_token::mint = mint,
         associated_token::authority = sender,
     )]
-    pub sender_ata: InterfaceAccount<'info, TokenAccount>,
+    pub sender_token_account: InterfaceAccount<'info, TokenAccount>,
 
     #[account(
         mut,
@@ -40,7 +40,7 @@ pub struct AddSplGas<'info> {
         associated_token::mint = mint,
         associated_token::authority = treasury,
     )]
-    pub treasury_ata: InterfaceAccount<'info, TokenAccount>,
+    pub treasury_token_account: InterfaceAccount<'info, TokenAccount>,
 
     pub mint: InterfaceAccount<'info, Mint>,
 
@@ -64,8 +64,8 @@ pub fn add_spl_gas<'info>(
 
     let cpi_accounts = TransferChecked {
         mint: ctx.accounts.mint.to_account_info().clone(),
-        from: ctx.accounts.sender_ata.to_account_info().clone(),
-        to: ctx.accounts.treasury_ata.to_account_info().clone(),
+        from: ctx.accounts.sender_token_account.to_account_info().clone(),
+        to: ctx.accounts.treasury_token_account.to_account_info().clone(),
         authority: ctx.accounts.sender.to_account_info().clone(),
     };
     let cpi_program = ctx.accounts.token_program.to_account_info();
@@ -76,7 +76,7 @@ pub fn add_spl_gas<'info>(
 
     emit_cpi!(SplGasAddedEvent {
         config_pda: *ctx.accounts.treasury.to_account_info().key,
-        config_pda_ata: *ctx.accounts.treasury_ata.to_account_info().key,
+        config_pda_token_account: *ctx.accounts.treasury_token_account.to_account_info().key,
         mint: *ctx.accounts.mint.to_account_info().key,
         token_program_id: *ctx.accounts.token_program.to_account_info().key,
         tx_hash,

--- a/programs/axelar-solana-gas-service-v2/src/instructions/add_spl_gas.rs
+++ b/programs/axelar-solana-gas-service-v2/src/instructions/add_spl_gas.rs
@@ -79,7 +79,7 @@ pub fn add_spl_gas<'info>(
     token_interface::transfer_checked(cpi_context, gas_fee_amount, decimals)?;
 
     emit_cpi!(SplGasAddedEvent {
-        config_pda: *ctx.accounts.treasury.to_account_info().key,
+        treasury: *ctx.accounts.treasury.to_account_info().key,
         config_pda_token_account: *ctx.accounts.treasury_token_account.to_account_info().key,
         mint: *ctx.accounts.mint.to_account_info().key,
         token_program_id: *ctx.accounts.token_program.to_account_info().key,

--- a/programs/axelar-solana-gas-service-v2/src/instructions/add_spl_gas.rs
+++ b/programs/axelar-solana-gas-service-v2/src/instructions/add_spl_gas.rs
@@ -65,7 +65,11 @@ pub fn add_spl_gas<'info>(
     let cpi_accounts = TransferChecked {
         mint: ctx.accounts.mint.to_account_info().clone(),
         from: ctx.accounts.sender_token_account.to_account_info().clone(),
-        to: ctx.accounts.treasury_token_account.to_account_info().clone(),
+        to: ctx
+            .accounts
+            .treasury_token_account
+            .to_account_info()
+            .clone(),
         authority: ctx.accounts.sender.to_account_info().clone(),
     };
     let cpi_program = ctx.accounts.token_program.to_account_info();

--- a/programs/axelar-solana-gas-service-v2/src/instructions/add_spl_gas.rs
+++ b/programs/axelar-solana-gas-service-v2/src/instructions/add_spl_gas.rs
@@ -8,8 +8,8 @@ use axelar_solana_gas_service_events::events::SplGasAddedEvent;
 /// Accounts expected:
 /// 0. `[signer, writable]` The account (`sender`) paying the gas fee in SPL tokens.
 /// 1. `[writable]` The sender's associated token account for the mint.
-/// 2. `[writable]` The `config_pda` account.
-/// 3. `[writable]` The config PDA's associated token account for the mint.
+/// 2. `[writable]` The `treasury` account.
+/// 3. `[writable]` The treasury's associated token account for the mint.
 /// 4. `[]` The mint account for the SPL token.
 /// 5. `[]` The SPL token program.
 /// 6+. `[signer, writable]` Optional additional accounts required by the SPL token program for the transfer.
@@ -80,7 +80,7 @@ pub fn add_spl_gas<'info>(
 
     emit_cpi!(SplGasAddedEvent {
         treasury: *ctx.accounts.treasury.to_account_info().key,
-        config_pda_token_account: *ctx.accounts.treasury_token_account.to_account_info().key,
+        treasury_token_account: *ctx.accounts.treasury_token_account.to_account_info().key,
         mint: *ctx.accounts.mint.to_account_info().key,
         token_program_id: *ctx.accounts.token_program.to_account_info().key,
         tx_hash,

--- a/programs/axelar-solana-gas-service-v2/src/instructions/collect_spl_fees.rs
+++ b/programs/axelar-solana-gas-service-v2/src/instructions/collect_spl_fees.rs
@@ -22,7 +22,7 @@ pub struct CollectSplFees<'info> {
         mut,
         token::mint = mint,
     )]
-    pub receiver_account: InterfaceAccount<'info, TokenAccount>,
+    pub receiver_token_account: InterfaceAccount<'info, TokenAccount>,
 
     #[account(
         mut,
@@ -38,7 +38,7 @@ pub struct CollectSplFees<'info> {
         associated_token::mint = mint,
         associated_token::authority = treasury,
     )]
-    pub treasury_ata: InterfaceAccount<'info, TokenAccount>,
+    pub treasury_token_account: InterfaceAccount<'info, TokenAccount>,
 
     pub mint: InterfaceAccount<'info, Mint>,
 
@@ -55,8 +55,8 @@ pub fn collect_spl_fees(ctx: Context<CollectSplFees>, amount: u64, decimals: u8)
 
     let cpi_accounts = TransferChecked {
         mint: ctx.accounts.mint.to_account_info().clone(),
-        from: ctx.accounts.treasury_ata.to_account_info().clone(),
-        to: ctx.accounts.receiver_account.to_account_info().clone(),
+        from: ctx.accounts.treasury_token_account.to_account_info().clone(),
+        to: ctx.accounts.receiver_token_account.to_account_info().clone(),
         authority: ctx.accounts.treasury.to_account_info().clone(),
     };
     let cpi_program = ctx.accounts.token_program.to_account_info();

--- a/programs/axelar-solana-gas-service-v2/src/instructions/collect_spl_fees.rs
+++ b/programs/axelar-solana-gas-service-v2/src/instructions/collect_spl_fees.rs
@@ -55,8 +55,16 @@ pub fn collect_spl_fees(ctx: Context<CollectSplFees>, amount: u64, decimals: u8)
 
     let cpi_accounts = TransferChecked {
         mint: ctx.accounts.mint.to_account_info().clone(),
-        from: ctx.accounts.treasury_token_account.to_account_info().clone(),
-        to: ctx.accounts.receiver_token_account.to_account_info().clone(),
+        from: ctx
+            .accounts
+            .treasury_token_account
+            .to_account_info()
+            .clone(),
+        to: ctx
+            .accounts
+            .receiver_token_account
+            .to_account_info()
+            .clone(),
         authority: ctx.accounts.treasury.to_account_info().clone(),
     };
     let cpi_program = ctx.accounts.token_program.to_account_info();

--- a/programs/axelar-solana-gas-service-v2/src/instructions/pay_native_for_contract_call.rs
+++ b/programs/axelar-solana-gas-service-v2/src/instructions/pay_native_for_contract_call.rs
@@ -6,7 +6,7 @@ use axelar_solana_gas_service_events::events::NativeGasPaidForContractCallEvent;
 ///
 /// Accounts expected:
 /// 0. `[signer, writable]` The account (`payer`) paying the gas fee in lamports.
-/// 1. `[writable]` The `config_pda` account that receives the lamports.
+/// 1. `[writable]` The `treasury` account that receives the lamports.
 /// 2. `[]` The `system_program` account.
 #[event_cpi]
 #[derive(Accounts)]

--- a/programs/axelar-solana-gas-service-v2/src/instructions/pay_native_for_contract_call.rs
+++ b/programs/axelar-solana-gas-service-v2/src/instructions/pay_native_for_contract_call.rs
@@ -54,7 +54,7 @@ pub fn pay_native_for_contract_call(
     )?;
 
     emit_cpi!(NativeGasPaidForContractCallEvent {
-        config_pda: *treasury_account_info.key,
+        treasury: *treasury_account_info.key,
         destination_chain: destination_chain.clone(),
         destination_address: destination_address.clone(),
         payload_hash,

--- a/programs/axelar-solana-gas-service-v2/src/instructions/pay_spl_for_contract_call.rs
+++ b/programs/axelar-solana-gas-service-v2/src/instructions/pay_spl_for_contract_call.rs
@@ -15,7 +15,7 @@ pub struct PaySplForContractCall<'info> {
         associated_token::mint = mint,
         associated_token::authority = sender,
     )]
-    pub sender_ata: InterfaceAccount<'info, TokenAccount>,
+    pub sender_token_account: InterfaceAccount<'info, TokenAccount>,
 
     #[account(
         mut,
@@ -31,7 +31,7 @@ pub struct PaySplForContractCall<'info> {
         associated_token::mint = mint,
         associated_token::authority = treasury,
     )]
-    pub treasury_ata: InterfaceAccount<'info, TokenAccount>,
+    pub treasury_token_account: InterfaceAccount<'info, TokenAccount>,
 
     pub mint: InterfaceAccount<'info, Mint>,
 
@@ -57,8 +57,8 @@ pub fn pay_spl_for_contract_call<'info>(
 
     let cpi_accounts = TransferChecked {
         mint: ctx.accounts.mint.to_account_info().clone(),
-        from: ctx.accounts.sender_ata.to_account_info().clone(),
-        to: ctx.accounts.treasury_ata.to_account_info().clone(),
+        from: ctx.accounts.sender_token_account.to_account_info().clone(),
+        to: ctx.accounts.treasury_token_account.to_account_info().clone(),
         authority: ctx.accounts.sender.to_account_info().clone(),
     };
     let cpi_program = ctx.accounts.token_program.to_account_info();
@@ -69,7 +69,7 @@ pub fn pay_spl_for_contract_call<'info>(
 
     emit_cpi!(SplGasPaidForContractCallEvent {
         config_pda: *ctx.accounts.treasury.to_account_info().key,
-        config_pda_ata: *ctx.accounts.treasury_ata.to_account_info().key,
+        config_pda_token_account: *ctx.accounts.treasury_token_account.to_account_info().key,
         mint: *ctx.accounts.mint.to_account_info().key,
         token_program_id: *ctx.accounts.token_program.key,
         destination_chain: destination_chain.clone(),

--- a/programs/axelar-solana-gas-service-v2/src/instructions/pay_spl_for_contract_call.rs
+++ b/programs/axelar-solana-gas-service-v2/src/instructions/pay_spl_for_contract_call.rs
@@ -72,7 +72,7 @@ pub fn pay_spl_for_contract_call<'info>(
     token_interface::transfer_checked(cpi_context, gas_fee_amount, decimals)?;
 
     emit_cpi!(SplGasPaidForContractCallEvent {
-        config_pda: *ctx.accounts.treasury.to_account_info().key,
+        treasury: *ctx.accounts.treasury.to_account_info().key,
         config_pda_token_account: *ctx.accounts.treasury_token_account.to_account_info().key,
         mint: *ctx.accounts.mint.to_account_info().key,
         token_program_id: *ctx.accounts.token_program.key,

--- a/programs/axelar-solana-gas-service-v2/src/instructions/pay_spl_for_contract_call.rs
+++ b/programs/axelar-solana-gas-service-v2/src/instructions/pay_spl_for_contract_call.rs
@@ -58,7 +58,11 @@ pub fn pay_spl_for_contract_call<'info>(
     let cpi_accounts = TransferChecked {
         mint: ctx.accounts.mint.to_account_info().clone(),
         from: ctx.accounts.sender_token_account.to_account_info().clone(),
-        to: ctx.accounts.treasury_token_account.to_account_info().clone(),
+        to: ctx
+            .accounts
+            .treasury_token_account
+            .to_account_info()
+            .clone(),
         authority: ctx.accounts.sender.to_account_info().clone(),
     };
     let cpi_program = ctx.accounts.token_program.to_account_info();

--- a/programs/axelar-solana-gas-service-v2/src/instructions/pay_spl_for_contract_call.rs
+++ b/programs/axelar-solana-gas-service-v2/src/instructions/pay_spl_for_contract_call.rs
@@ -73,7 +73,7 @@ pub fn pay_spl_for_contract_call<'info>(
 
     emit_cpi!(SplGasPaidForContractCallEvent {
         treasury: *ctx.accounts.treasury.to_account_info().key,
-        config_pda_token_account: *ctx.accounts.treasury_token_account.to_account_info().key,
+        treasury_token_account: *ctx.accounts.treasury_token_account.to_account_info().key,
         mint: *ctx.accounts.mint.to_account_info().key,
         token_program_id: *ctx.accounts.token_program.key,
         destination_chain: destination_chain.clone(),

--- a/programs/axelar-solana-gas-service-v2/src/instructions/refund_native_fees.rs
+++ b/programs/axelar-solana-gas-service-v2/src/instructions/refund_native_fees.rs
@@ -53,7 +53,7 @@ pub fn refund_native_fees(
 
     emit_cpi!(NativeGasRefundedEvent {
         tx_hash,
-        config_pda: *ctx.accounts.treasury.to_account_info().key,
+        treasury: *ctx.accounts.treasury.to_account_info().key,
         log_index,
         receiver: *ctx.accounts.receiver.to_account_info().key,
         fees,

--- a/programs/axelar-solana-gas-service-v2/src/instructions/refund_spl_fees.rs
+++ b/programs/axelar-solana-gas-service-v2/src/instructions/refund_spl_fees.rs
@@ -9,8 +9,8 @@ use axelar_solana_operators::OperatorAccount;
 /// Accounts expected:
 /// 0. `[signer, read-only]` The `operator` account authorized to collect fees.
 /// 1. `[writable]` The `receiver` account where the tokens will be sent.
-/// 2. `[writable]` The `config_pda` account.
-/// 3. `[writable]` The config PDA's associated token account for the mint.
+/// 2. `[writable]` The `treasury` account.
+/// 3. `[writable]` The treasury's associated token account for the mint.
 /// 4. `[]` The mint account for the SPL token.
 /// 5. `[]` The SPL token program.
 #[event_cpi]
@@ -89,7 +89,7 @@ pub fn refund_spl_fees(
     token_interface::transfer_checked(cpi_context, fees, decimals)?;
 
     emit_cpi!(SplGasRefundedEvent {
-        config_pda_token_account: *ctx.accounts.treasury_token_account.to_account_info().key,
+        treasury_token_account: *ctx.accounts.treasury_token_account.to_account_info().key,
         mint: *ctx.accounts.mint.to_account_info().key,
         token_program_id: *ctx.accounts.token_program.to_account_info().key,
         tx_hash,

--- a/programs/axelar-solana-gas-service-v2/src/instructions/refund_spl_fees.rs
+++ b/programs/axelar-solana-gas-service-v2/src/instructions/refund_spl_fees.rs
@@ -32,7 +32,7 @@ pub struct RefundSplFees<'info> {
         mut,
         token::mint = mint,
     )]
-    pub receiver_account: InterfaceAccount<'info, TokenAccount>,
+    pub receiver_token_account: InterfaceAccount<'info, TokenAccount>,
 
     #[account(
         mut,
@@ -48,7 +48,7 @@ pub struct RefundSplFees<'info> {
         associated_token::mint = mint,
         associated_token::authority = treasury,
     )]
-    pub treasury_ata: InterfaceAccount<'info, TokenAccount>,
+    pub treasury_token_account: InterfaceAccount<'info, TokenAccount>,
 
     pub mint: InterfaceAccount<'info, Mint>,
 
@@ -71,8 +71,8 @@ pub fn refund_spl_fees(
 
     let cpi_accounts = TransferChecked {
         mint: ctx.accounts.mint.to_account_info().clone(),
-        from: ctx.accounts.treasury_ata.to_account_info().clone(),
-        to: ctx.accounts.receiver_account.to_account_info().clone(),
+        from: ctx.accounts.treasury_token_account.to_account_info().clone(),
+        to: ctx.accounts.receiver_token_account.to_account_info().clone(),
         authority: ctx.accounts.treasury.to_account_info().clone(),
     };
     let cpi_program = ctx.accounts.token_program.to_account_info();
@@ -81,13 +81,13 @@ pub fn refund_spl_fees(
     token_interface::transfer_checked(cpi_context, fees, decimals)?;
 
     emit_cpi!(SplGasRefundedEvent {
-        config_pda_ata: *ctx.accounts.treasury_ata.to_account_info().key,
+        config_pda_token_account: *ctx.accounts.treasury_token_account.to_account_info().key,
         mint: *ctx.accounts.mint.to_account_info().key,
         token_program_id: *ctx.accounts.token_program.to_account_info().key,
         tx_hash,
         config_pda: *ctx.accounts.treasury.to_account_info().key,
         log_index,
-        receiver: *ctx.accounts.receiver_account.to_account_info().key,
+        receiver: *ctx.accounts.receiver_token_account.to_account_info().key,
         fees,
     });
 

--- a/programs/axelar-solana-gas-service-v2/src/instructions/refund_spl_fees.rs
+++ b/programs/axelar-solana-gas-service-v2/src/instructions/refund_spl_fees.rs
@@ -93,7 +93,7 @@ pub fn refund_spl_fees(
         mint: *ctx.accounts.mint.to_account_info().key,
         token_program_id: *ctx.accounts.token_program.to_account_info().key,
         tx_hash,
-        config_pda: *ctx.accounts.treasury.to_account_info().key,
+        treasury: *ctx.accounts.treasury.to_account_info().key,
         log_index,
         receiver: *ctx.accounts.receiver_token_account.to_account_info().key,
         fees,

--- a/programs/axelar-solana-gas-service-v2/src/instructions/refund_spl_fees.rs
+++ b/programs/axelar-solana-gas-service-v2/src/instructions/refund_spl_fees.rs
@@ -71,8 +71,16 @@ pub fn refund_spl_fees(
 
     let cpi_accounts = TransferChecked {
         mint: ctx.accounts.mint.to_account_info().clone(),
-        from: ctx.accounts.treasury_token_account.to_account_info().clone(),
-        to: ctx.accounts.receiver_token_account.to_account_info().clone(),
+        from: ctx
+            .accounts
+            .treasury_token_account
+            .to_account_info()
+            .clone(),
+        to: ctx
+            .accounts
+            .receiver_token_account
+            .to_account_info()
+            .clone(),
         authority: ctx.accounts.treasury.to_account_info().clone(),
     };
     let cpi_program = ctx.accounts.token_program.to_account_info();

--- a/programs/axelar-solana-gas-service/src/processor.rs
+++ b/programs/axelar-solana-gas-service/src/processor.rs
@@ -11,7 +11,8 @@ use crate::{
 use self::{
     initialize::process_initialize_config,
     native::{
-        add_native_gas, collect_fees_native, process_pay_native_gas_for_contract_call, refund_native,
+        add_native_gas, collect_fees_native, process_pay_native_gas_for_contract_call,
+        refund_native,
     },
     spl::{add_spl_gas, collect_fees_spl, process_pay_spl_gas_for_contract_call, refund_spl},
     transfer_operatorship::process_transfer_operatorship,

--- a/programs/axelar-solana-gas-service/tests/module/native/pay_for_contract_call.rs
+++ b/programs/axelar-solana-gas-service/tests/module/native/pay_for_contract_call.rs
@@ -131,16 +131,17 @@ async fn fails_if_payer_not_signer() {
     let params = "\u{1f42a}\u{1f42a}\u{1f42a}\u{1f42a}"
         .to_string()
         .into_bytes();
-    let mut ix = axelar_solana_gas_service::instructions::pay_native_gas_for_contract_call_instruction(
-        &payer.pubkey(),
-        destination_chain.clone(),
-        destination_addr.clone(),
-        payload_hash,
-        refund_address,
-        params.clone(),
-        gas_amount,
-    )
-    .unwrap();
+    let mut ix =
+        axelar_solana_gas_service::instructions::pay_native_gas_for_contract_call_instruction(
+            &payer.pubkey(),
+            destination_chain.clone(),
+            destination_addr.clone(),
+            payload_hash,
+            refund_address,
+            params.clone(),
+            gas_amount,
+        )
+        .unwrap();
     ix.accounts[0].is_signer = false;
 
     let res = test_fixture


### PR DESCRIPTION
**Referenced issue**

C4 -- Misleading terminology ”sender_ata” and “config_pda_ata”

**Summary of changes**

Fix: Add IdlBuild trait import for #[event] macro compatibility
- Added idl-build feature to anchor-lang dependency in Cargo.toml
- Imported IdlBuild trait in axelar-solana-gas-service-events/src/events.rs
- Resolves compilation errors for all #[event] structs

fix(gas-service-v2): apply terminology improvements from PR https://github.com/eigerco/axelar-amplifier-solana/pull/268
- Rename misleading terminology for better clarity:
  - sender_ata → sender_token_account
  - treasury_ata → treasury_token_account
  - receiver_account → receiver_token_account
  - config_pda_ata → config_pda_token_account

- Updated all SPL instruction files:
  - pay_spl_for_contract_call.rs
  - add_spl_gas.rs
  - refund_spl_fees.rs
  - collect_spl_fees.rs

- Updated event structures in axelar-solana-gas-service-events