### PR TITLE
Fix: port C5 to gas service v2

### DIFF
--- a/crates/axelar-solana-gas-service-events/src/events.rs
+++ b/crates/axelar-solana-gas-service-events/src/events.rs
@@ -37,8 +37,6 @@ pub struct NativeGasPaidForContractCallEvent {
     pub payload_hash: [u8; 32],
     /// The refund address
     pub refund_address: Pubkey,
-    /// Extra parameters to be passed
-    pub params: Vec<u8>,
     /// The amount of SOL to send
     pub gas_fee_amount: u64,
 }
@@ -75,8 +73,6 @@ impl NativeGasPaidForContractCallEvent {
         let refund_address =
             Pubkey::new_from_array(read_array::<32>("refund_address", &refund_address_data)?);
 
-        let params = data.next().ok_or(EventParseError::MissingData("params"))?;
-
         let gas_fee_amount_data = data
             .next()
             .ok_or(EventParseError::MissingData("gas_fee_amount"))?;
@@ -88,7 +84,6 @@ impl NativeGasPaidForContractCallEvent {
             destination_address,
             payload_hash,
             refund_address,
-            params,
             gas_fee_amount,
         })
     }
@@ -223,8 +218,6 @@ pub struct SplGasPaidForContractCallEvent {
     pub payload_hash: [u8; 32],
     /// The refund address
     pub refund_address: Pubkey,
-    /// Extra parameters to be passed
-    pub params: Vec<u8>,
     /// The amount of SOL to send
     pub gas_fee_amount: u64,
 }
@@ -278,8 +271,6 @@ impl SplGasPaidForContractCallEvent {
         let refund_address =
             Pubkey::new_from_array(read_array::<32>("refund_address", &refund_address_data)?);
 
-        let params = data.next().ok_or(EventParseError::MissingData("params"))?;
-
         let gas_fee_amount_data = data
             .next()
             .ok_or(EventParseError::MissingData("gas_fee_amount"))?;
@@ -294,7 +285,6 @@ impl SplGasPaidForContractCallEvent {
             destination_address,
             payload_hash,
             refund_address,
-            params,
             gas_fee_amount,
         })
     }

--- a/crates/gateway-event-stack/src/lib.rs
+++ b/crates/gateway-event-stack/src/lib.rs
@@ -442,7 +442,6 @@ mod tests {
                 193, 191, 38, 1, 250, 10, 98, 37, 164, 74, 132, 208, 191, 145,
             ],
             refund_address: "11111112D1oxKts8YPdTJRG5FzxTNpMtWmq8hkVx3".parse().unwrap(),
-            params: vec![],
             gas_fee_amount: 5000,
         };
         let expected = vec![ProgramInvocationState::Succeeded(vec![(

--- a/programs/axelar-solana-gas-service-v2/src/instructions/pay_native_for_contract_call.rs
+++ b/programs/axelar-solana-gas-service-v2/src/instructions/pay_native_for_contract_call.rs
@@ -32,7 +32,6 @@ pub fn pay_native_for_contract_call(
     destination_address: String,
     payload_hash: [u8; 32],
     refund_address: Pubkey,
-    params: &[u8],
     gas_fee_amount: u64,
 ) -> Result<()> {
     if gas_fee_amount == 0 {
@@ -59,7 +58,6 @@ pub fn pay_native_for_contract_call(
         destination_address: destination_address.clone(),
         payload_hash,
         refund_address,
-        params: params.to_vec(),
         gas_fee_amount,
     });
 

--- a/programs/axelar-solana-gas-service-v2/src/instructions/pay_spl_for_contract_call.rs
+++ b/programs/axelar-solana-gas-service-v2/src/instructions/pay_spl_for_contract_call.rs
@@ -45,7 +45,6 @@ pub fn pay_spl_for_contract_call<'info>(
     destination_chain: String,
     destination_address: String,
     payload_hash: [u8; 32],
-    params: &[u8],
     gas_fee_amount: u64,
     decimals: u8,
     refund_address: Pubkey,
@@ -80,7 +79,6 @@ pub fn pay_spl_for_contract_call<'info>(
         destination_address: destination_address.clone(),
         payload_hash,
         refund_address,
-        params: params.to_vec(),
         gas_fee_amount,
     });
 

--- a/programs/axelar-solana-gas-service-v2/src/lib.rs
+++ b/programs/axelar-solana-gas-service-v2/src/lib.rs
@@ -67,7 +67,6 @@ pub mod axelar_solana_gas_service_v2 {
         destination_address: String,
         payload_hash: [u8; 32],
         gas_fee_amount: u64,
-        params: Vec<u8>,
         decimals: u8,
         refund_address: Pubkey,
     ) -> Result<()> {
@@ -76,7 +75,6 @@ pub mod axelar_solana_gas_service_v2 {
             destination_chain,
             destination_address,
             payload_hash,
-            &params,
             gas_fee_amount,
             decimals,
             refund_address,
@@ -129,7 +127,6 @@ pub mod axelar_solana_gas_service_v2 {
         destination_address: String,
         payload_hash: [u8; 32],
         refund_address: Pubkey,
-        params: Vec<u8>,
         gas_fee_amount: u64,
     ) -> Result<()> {
         instructions::pay_native_for_contract_call::pay_native_for_contract_call(
@@ -138,7 +135,6 @@ pub mod axelar_solana_gas_service_v2 {
             destination_address,
             payload_hash,
             refund_address,
-            &params,
             gas_fee_amount,
         )
     }

--- a/programs/axelar-solana-gas-service-v2/tests/discriminators.rs
+++ b/programs/axelar-solana-gas-service-v2/tests/discriminators.rs
@@ -36,7 +36,6 @@ fn test_discriminators_backwards_compatible() {
             "0x123".to_string(),
             [0u8; 32],
             Pubkey::default(),
-            vec![],
             1000,
         )
         .unwrap(),
@@ -77,7 +76,6 @@ fn test_discriminators_backwards_compatible() {
             "0x456".to_string(),
             [1u8; 32],
             Pubkey::default(),
-            vec![1, 2, 3],
             2000,
             &[],
             6,

--- a/programs/axelar-solana-gas-service-v2/tests/pay_native_for_contract_call.rs
+++ b/programs/axelar-solana-gas-service-v2/tests/pay_native_for_contract_call.rs
@@ -60,7 +60,6 @@ fn test_pay_native_contract_call() {
             destination_address: "address".to_string(),
             payload_hash: [0u8; 32],
             refund_address,
-            params: vec![],
             gas_fee_amount,
         }
         .data(),

--- a/programs/axelar-solana-gas-service/src/instructions.rs
+++ b/programs/axelar-solana-gas-service/src/instructions.rs
@@ -221,7 +221,6 @@ pub fn pay_native_gas_for_contract_call_instruction(
     destination_address: String,
     payload_hash: [u8; 32],
     refund_address: Pubkey,
-    params: Vec<u8>,
     gas_fee_amount: u64,
 ) -> Result<Instruction, ProgramError> {
     let ix_data = borsh::to_vec(&GasServiceInstruction::Native(
@@ -353,7 +352,6 @@ pub fn pay_spl_gas_for_contract_call_instruction(
     destination_address: String,
     payload_hash: [u8; 32],
     refund_address: Pubkey,
-    params: Vec<u8>,
     gas_fee_amount: u64,
     signer_pubkeys: &[Pubkey],
     decimals: u8,


### PR DESCRIPTION
**Referenced issue**

Unused, unnecessary or legacy code

**Summary of changes**

- Remove unused params field from event structures:
  - NativeGasPaidForContractCallEvent
  - SplGasPaidForContractCallEvent

- Remove params parameter from function signatures:
  - pay_spl_for_contract_call() in lib.rs and instruction file
  - pay_native_for_contract_call() in lib.rs and instruction file

- Update event parsing code to remove params handling

- Fix test fixtures in gateway-event-stack to remove params usage