### PR TITLE
refactor: make treasury backwards compatible + update gas service events

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1104,6 +1104,7 @@ dependencies = [
  "axelar-solana-gateway-test-fixtures",
  "axelar-solana-operators",
  "borsh 1.5.7",
+ "bytemuck",
  "mollusk-svm",
  "program-utils",
  "solana-sdk",

--- a/programs/axelar-solana-gas-service-v2/Cargo.toml
+++ b/programs/axelar-solana-gas-service-v2/Cargo.toml
@@ -12,6 +12,7 @@ anchor-lang.workspace = true
 anchor-spl.workspace = true
 axelar-solana-operators = { workspace = true, features = ["no-entrypoint"] }
 program-utils.workspace = true
+bytemuck.workspace = true
 
 [dev-dependencies]
 axelar-solana-gateway-test-fixtures.workspace = true

--- a/programs/axelar-solana-gas-service-v2/src/events.rs
+++ b/programs/axelar-solana-gas-service-v2/src/events.rs
@@ -47,8 +47,10 @@ pub struct NativeGasAddedEvent {
     pub treasury: Pubkey,
     /// Solana transaction signature
     pub tx_hash: [u8; 64],
-    /// index of the log
-    pub log_index: u64,
+    /// Index of the CallContract instruction
+    pub ix_index: u8,
+    /// Index of the CPI event inside inner instructions
+    pub event_ix_index: u8,
     /// The refund address
     pub refund_address: Pubkey,
     /// amount of SOL
@@ -63,8 +65,10 @@ pub struct NativeGasRefundedEvent {
     pub tx_hash: [u8; 64],
     /// The Gas service treasury PDA
     pub treasury: Pubkey,
-    /// The log index
-    pub log_index: u64,
+    /// Index of the CallContract instruction
+    pub ix_index: u8,
+    /// Index of the CPI event inside inner instructions
+    pub event_ix_index: u8,
     /// The receiver of the refund
     pub receiver: Pubkey,
     /// amount of SOL
@@ -109,8 +113,10 @@ pub struct SplGasAddedEvent {
     pub token_program_id: Pubkey,
     /// Solana transaction signature
     pub tx_hash: [u8; 64],
-    /// index of the log
-    pub log_index: u64,
+    /// Index of the CallContract instruction
+    pub ix_index: u8,
+    /// Index of the CPI event inside inner instructions
+    pub event_ix_index: u8,
     /// The refund address
     pub refund_address: Pubkey,
     /// amount of SOL
@@ -131,8 +137,10 @@ pub struct SplGasRefundedEvent {
     pub tx_hash: [u8; 64],
     /// The Gas service treasury PDA
     pub treasury: Pubkey,
-    /// The log index
-    pub log_index: u64,
+    /// Index of the CallContract instruction
+    pub ix_index: u8,
+    /// Index of the CPI event inside inner instructions
+    pub event_ix_index: u8,
     /// The receiver of the refund
     pub receiver: Pubkey,
     /// amount of SOL

--- a/programs/axelar-solana-gas-service-v2/src/instructions/add_native_gas.rs
+++ b/programs/axelar-solana-gas-service-v2/src/instructions/add_native_gas.rs
@@ -14,9 +14,9 @@ pub struct AddNativeGas<'info> {
         seeds = [
             Treasury::SEED_PREFIX,
         ],
-        bump = treasury.bump,
+        bump = treasury.load()?.bump,
     )]
-    pub treasury: Account<'info, Treasury>,
+    pub treasury: AccountLoader<'info, Treasury>,
 
     pub system_program: Program<'info, System>,
 }
@@ -24,7 +24,8 @@ pub struct AddNativeGas<'info> {
 pub fn add_native_gas(
     ctx: Context<AddNativeGas>,
     tx_hash: [u8; 64],
-    log_index: u64,
+    ix_index: u8,
+    event_ix_index: u8,
     gas_fee_amount: u64,
     refund_address: Pubkey,
 ) -> Result<()> {
@@ -49,7 +50,8 @@ pub fn add_native_gas(
     emit_cpi!(NativeGasAddedEvent {
         treasury: *treasury_account_info.key,
         tx_hash,
-        log_index,
+        ix_index,
+        event_ix_index,
         refund_address,
         gas_fee_amount,
     });

--- a/programs/axelar-solana-gas-service-v2/src/instructions/add_spl_gas.rs
+++ b/programs/axelar-solana-gas-service-v2/src/instructions/add_spl_gas.rs
@@ -31,9 +31,9 @@ pub struct AddSplGas<'info> {
         seeds = [
             Treasury::SEED_PREFIX,
         ],
-        bump = treasury.bump,
+        bump = treasury.load()?.bump,
     )]
-    pub treasury: Account<'info, Treasury>,
+    pub treasury: AccountLoader<'info, Treasury>,
 
     #[account(
         mut,
@@ -52,7 +52,8 @@ pub fn add_spl_gas<'info>(
     // see more: https://solana.stackexchange.com/questions/13275/cpicontext-with-remaining-accounts-is-not-working-because-of-lifetimes
     ctx: Context<'_, '_, '_, 'info, AddSplGas<'info>>,
     tx_hash: [u8; 64],
-    log_index: u64,
+    ix_index: u8,
+    event_ix_index: u8,
     gas_fee_amount: u64,
     decimals: u8,
     refund_address: Pubkey,
@@ -65,7 +66,11 @@ pub fn add_spl_gas<'info>(
     let cpi_accounts = TransferChecked {
         mint: ctx.accounts.mint.to_account_info().clone(),
         from: ctx.accounts.sender_token_account.to_account_info().clone(),
-        to: ctx.accounts.treasury_token_account.to_account_info().clone(),
+        to: ctx
+            .accounts
+            .treasury_token_account
+            .to_account_info()
+            .clone(),
         authority: ctx.accounts.sender.to_account_info().clone(),
     };
     let cpi_program = ctx.accounts.token_program.to_account_info();
@@ -80,7 +85,8 @@ pub fn add_spl_gas<'info>(
         mint: *ctx.accounts.mint.to_account_info().key,
         token_program_id: *ctx.accounts.token_program.to_account_info().key,
         tx_hash,
-        log_index,
+        ix_index,
+        event_ix_index,
         refund_address,
         gas_fee_amount,
     });

--- a/programs/axelar-solana-gas-service-v2/src/instructions/collect_native_fees.rs
+++ b/programs/axelar-solana-gas-service-v2/src/instructions/collect_native_fees.rs
@@ -28,9 +28,9 @@ pub struct CollectNativeFees<'info> {
         seeds = [
             Treasury::SEED_PREFIX,
         ],
-        bump = treasury.bump,
+        bump = treasury.load()?.bump,
     )]
-    pub treasury: Account<'info, Treasury>,
+    pub treasury: AccountLoader<'info, Treasury>,
 
     /// CHECK: Can be any account to receive funds
     #[account(mut)]

--- a/programs/axelar-solana-gas-service-v2/src/instructions/collect_spl_fees.rs
+++ b/programs/axelar-solana-gas-service-v2/src/instructions/collect_spl_fees.rs
@@ -29,9 +29,9 @@ pub struct CollectSplFees<'info> {
         seeds = [
             Treasury::SEED_PREFIX,
         ],
-        bump = treasury.bump,
+        bump = treasury.load()?.bump,
     )]
-    pub treasury: Account<'info, Treasury>,
+    pub treasury: AccountLoader<'info, Treasury>,
 
     #[account(
         mut,
@@ -51,12 +51,21 @@ pub fn collect_spl_fees(ctx: Context<CollectSplFees>, amount: u64, decimals: u8)
         return Err(ProgramError::InvalidInstructionData.into());
     }
 
-    let signer_seeds: &[&[&[u8]]] = &[&[Treasury::SEED_PREFIX, &[ctx.accounts.treasury.bump]]];
+    let signer_seeds: &[&[&[u8]]] =
+        &[&[Treasury::SEED_PREFIX, &[ctx.accounts.treasury.load()?.bump]]];
 
     let cpi_accounts = TransferChecked {
         mint: ctx.accounts.mint.to_account_info().clone(),
-        from: ctx.accounts.treasury_token_account.to_account_info().clone(),
-        to: ctx.accounts.receiver_token_account.to_account_info().clone(),
+        from: ctx
+            .accounts
+            .treasury_token_account
+            .to_account_info()
+            .clone(),
+        to: ctx
+            .accounts
+            .receiver_token_account
+            .to_account_info()
+            .clone(),
         authority: ctx.accounts.treasury.to_account_info().clone(),
     };
     let cpi_program = ctx.accounts.token_program.to_account_info();

--- a/programs/axelar-solana-gas-service-v2/src/instructions/initialize.rs
+++ b/programs/axelar-solana-gas-service-v2/src/instructions/initialize.rs
@@ -31,11 +31,12 @@ pub struct Initialize<'info> {
         ],
         bump,
     )]
-    pub treasury: Account<'info, Treasury>,
+    pub treasury: AccountLoader<'info, Treasury>,
 }
 
 pub fn initialize(ctx: Context<Initialize>) -> Result<()> {
-    ctx.accounts.treasury.bump = ctx.bumps.treasury;
+    let treasury = &mut ctx.accounts.treasury.load_init()?;
+    treasury.bump = ctx.bumps.treasury;
 
     Ok(())
 }

--- a/programs/axelar-solana-gas-service-v2/src/instructions/pay_native_for_contract_call.rs
+++ b/programs/axelar-solana-gas-service-v2/src/instructions/pay_native_for_contract_call.rs
@@ -19,9 +19,9 @@ pub struct PayNativeForContractCall<'info> {
         seeds = [
             Treasury::SEED_PREFIX,
         ],
-        bump = treasury.bump,
+        bump = treasury.load()?.bump,
     )]
-    pub treasury: Account<'info, Treasury>,
+    pub treasury: AccountLoader<'info, Treasury>,
 
     pub system_program: Program<'info, System>,
 }

--- a/programs/axelar-solana-gas-service-v2/src/instructions/pay_spl_for_contract_call.rs
+++ b/programs/axelar-solana-gas-service-v2/src/instructions/pay_spl_for_contract_call.rs
@@ -22,9 +22,9 @@ pub struct PaySplForContractCall<'info> {
         seeds = [
             Treasury::SEED_PREFIX,
         ],
-        bump = treasury.bump,
+        bump = treasury.load()?.bump,
     )]
-    pub treasury: Account<'info, Treasury>,
+    pub treasury: AccountLoader<'info, Treasury>,
 
     #[account(
         mut,
@@ -57,7 +57,11 @@ pub fn pay_spl_for_contract_call<'info>(
     let cpi_accounts = TransferChecked {
         mint: ctx.accounts.mint.to_account_info().clone(),
         from: ctx.accounts.sender_token_account.to_account_info().clone(),
-        to: ctx.accounts.treasury_token_account.to_account_info().clone(),
+        to: ctx
+            .accounts
+            .treasury_token_account
+            .to_account_info()
+            .clone(),
         authority: ctx.accounts.sender.to_account_info().clone(),
     };
     let cpi_program = ctx.accounts.token_program.to_account_info();

--- a/programs/axelar-solana-gas-service-v2/src/instructions/refund_native_fees.rs
+++ b/programs/axelar-solana-gas-service-v2/src/instructions/refund_native_fees.rs
@@ -29,15 +29,16 @@ pub struct RefundNativeFees<'info> {
         seeds = [
             Treasury::SEED_PREFIX,
         ],
-        bump = treasury.bump,
+        bump = treasury.load()?.bump,
     )]
-    pub treasury: Account<'info, Treasury>,
+    pub treasury: AccountLoader<'info, Treasury>,
 }
 
 pub fn refund_native_fees(
     ctx: Context<RefundNativeFees>,
     tx_hash: [u8; 64],
-    log_index: u64,
+    ix_index: u8,
+    event_ix_index: u8,
     fees: u64,
 ) -> Result<()> {
     if fees == 0 {
@@ -54,7 +55,8 @@ pub fn refund_native_fees(
     emit_cpi!(NativeGasRefundedEvent {
         tx_hash,
         treasury: *ctx.accounts.treasury.to_account_info().key,
-        log_index,
+        ix_index,
+        event_ix_index,
         receiver: *ctx.accounts.receiver.to_account_info().key,
         fees,
     });

--- a/programs/axelar-solana-gas-service-v2/src/lib.rs
+++ b/programs/axelar-solana-gas-service-v2/src/lib.rs
@@ -61,7 +61,8 @@ pub mod axelar_solana_gas_service_v2 {
     pub fn add_spl_gas<'info>(
         ctx: Context<'_, '_, '_, 'info, AddSplGas<'info>>,
         tx_hash: [u8; 64],
-        log_index: u64,
+        ix_index: u8,
+        event_ix_index: u8,
         gas_fee_amount: u64,
         decimals: u8,
         refund_address: Pubkey,
@@ -69,7 +70,8 @@ pub mod axelar_solana_gas_service_v2 {
         instructions::add_spl_gas::add_spl_gas(
             ctx,
             tx_hash,
-            log_index,
+            ix_index,
+            event_ix_index,
             gas_fee_amount,
             decimals,
             refund_address,
@@ -83,11 +85,19 @@ pub mod axelar_solana_gas_service_v2 {
     pub fn refund_spl_fees(
         ctx: Context<RefundSplFees>,
         tx_hash: [u8; 64],
-        log_index: u64,
+        ix_index: u8,
+        event_ix_index: u8,
         fees: u64,
         decimals: u8,
     ) -> Result<()> {
-        instructions::refund_spl_fees::refund_spl_fees(ctx, tx_hash, log_index, fees, decimals)
+        instructions::refund_spl_fees::refund_spl_fees(
+            ctx,
+            tx_hash,
+            ix_index,
+            event_ix_index,
+            fees,
+            decimals,
+        )
     }
 
     //
@@ -115,14 +125,16 @@ pub mod axelar_solana_gas_service_v2 {
     pub fn add_native_gas(
         ctx: Context<AddNativeGas>,
         tx_hash: [u8; 64],
-        log_index: u64,
+        ix_index: u8,
+        event_ix_index: u8,
         gas_fee_amount: u64,
         refund_address: Pubkey,
     ) -> Result<()> {
         instructions::add_native_gas::add_native_gas(
             ctx,
             tx_hash,
-            log_index,
+            ix_index,
+            event_ix_index,
             gas_fee_amount,
             refund_address,
         )
@@ -135,9 +147,16 @@ pub mod axelar_solana_gas_service_v2 {
     pub fn refund_native_fees(
         ctx: Context<RefundNativeFees>,
         tx_hash: [u8; 64],
-        log_index: u64,
+        ix_index: u8,
+        event_ix_index: u8,
         fees: u64,
     ) -> Result<()> {
-        instructions::refund_native_fees::refund_native_fees(ctx, tx_hash, log_index, fees)
+        instructions::refund_native_fees::refund_native_fees(
+            ctx,
+            tx_hash,
+            ix_index,
+            event_ix_index,
+            fees,
+        )
     }
 }

--- a/programs/axelar-solana-gas-service-v2/src/state/treasury.rs
+++ b/programs/axelar-solana-gas-service-v2/src/state/treasury.rs
@@ -1,12 +1,15 @@
 use anchor_lang::prelude::*;
 
-#[account]
+#[account(zero_copy)]
 #[derive(InitSpace, PartialEq, Eq, Debug)]
+#[allow(clippy::partial_pub_fields)]
 pub struct Treasury {
+    #[doc(hidden)]
+    _old_operator: [u8; 32],
     /// The bump seed used to derive the PDA, ensuring the address is valid.
     pub bump: u8,
 }
 
 impl Treasury {
-    pub const SEED_PREFIX: &'static [u8] = b"treasury";
+    pub const SEED_PREFIX: &'static [u8] = b"gas-service";
 }

--- a/programs/axelar-solana-gas-service-v2/tests/add_native_gas.rs
+++ b/programs/axelar-solana-gas-service-v2/tests/add_native_gas.rs
@@ -39,7 +39,8 @@ fn test_add_native_gas() {
     let sender_account = Account::new(sender_balance, 0, &system_program::ID);
 
     let tx_hash = [0u8; 64];
-    let log_index = 0u64;
+    let ix_index = 1u8;
+    let event_ix_index = 2u8;
     let gas_fee_amount = 300_000_000u64; // 0.3 SOL
     let refund_address = Pubkey::new_unique();
 
@@ -61,7 +62,8 @@ fn test_add_native_gas() {
         .to_account_metas(None),
         data: axelar_solana_gas_service_v2::instruction::AddNativeGas {
             tx_hash,
-            log_index,
+            ix_index,
+            event_ix_index,
             gas_fee_amount,
             refund_address,
         }
@@ -134,7 +136,8 @@ fn test_add_native_gas_fails_for_zero() {
     let sender_account = Account::new(sender_balance, 0, &system_program::ID);
 
     let tx_hash = [0u8; 64];
-    let log_index = 0u64;
+    let ix_index = 1u8;
+    let event_ix_index = 2u8;
     let gas_fee_amount = 0u64; // 0 SOL
     let refund_address = Pubkey::new_unique();
 
@@ -156,7 +159,8 @@ fn test_add_native_gas_fails_for_zero() {
         .to_account_metas(None),
         data: axelar_solana_gas_service_v2::instruction::AddNativeGas {
             tx_hash,
-            log_index,
+            ix_index,
+            event_ix_index,
             gas_fee_amount,
             refund_address,
         }
@@ -225,7 +229,8 @@ fn test_add_native_gas_fails_insufficient_balance() {
     let sender_account = Account::new(sender_balance, 0, &system_program::ID);
 
     let tx_hash = [0u8; 64];
-    let log_index = 0u64;
+    let ix_index = 1u8;
+    let event_ix_index = 2u8;
     let gas_fee_amount = 500_000_000u64; // 0.3 SOL
     let refund_address = Pubkey::new_unique();
 
@@ -247,7 +252,8 @@ fn test_add_native_gas_fails_insufficient_balance() {
         .to_account_metas(None),
         data: axelar_solana_gas_service_v2::instruction::AddNativeGas {
             tx_hash,
-            log_index,
+            ix_index,
+            event_ix_index,
             gas_fee_amount,
             refund_address,
         }

--- a/programs/axelar-solana-gas-service-v2/tests/refund_native_fees.rs
+++ b/programs/axelar-solana-gas-service-v2/tests/refund_native_fees.rs
@@ -44,7 +44,8 @@ fn test_refund_native_fees() {
     let receiver_account = Account::new(receiver_balance, 0, &system_program::ID);
 
     let tx_hash = [0u8; 64];
-    let log_index = 0u64;
+    let ix_index = 1u8;
+    let event_ix_index = 2u8;
     let fees = 500_000_000u64; // 0.5 SOL
 
     let (event_authority, _bump) =
@@ -66,7 +67,8 @@ fn test_refund_native_fees() {
         .to_account_metas(None),
         data: axelar_solana_gas_service_v2::instruction::RefundNativeFees {
             tx_hash,
-            log_index,
+            ix_index,
+            event_ix_index,
             fees,
         }
         .data(),

--- a/programs/axelar-solana-gas-service-v2/tests/v1_compatibility.rs
+++ b/programs/axelar-solana-gas-service-v2/tests/v1_compatibility.rs
@@ -2,6 +2,7 @@
 use anchor_lang::InstructionData;
 use axelar_solana_gas_service::instructions as v1_instructions;
 use axelar_solana_gas_service_v2::instruction;
+use solana_sdk::pubkey::Pubkey;
 
 #[test]
 fn test_v1_instructions_compatibility() {
@@ -18,4 +19,28 @@ fn test_v1_instructions_compatibility() {
     assert_eq!(v1_collect_spl_fees, v2_collect_spl_fees);
 
     // TODO add rest of instructions
+}
+
+#[test]
+fn test_v1_treasury_compatibility() {
+    use axelar_solana_gas_service::state::Config;
+    use axelar_solana_gas_service_v2::state::Treasury;
+
+    assert_eq!(
+        std::mem::size_of::<Config>(),
+        std::mem::size_of::<Treasury>()
+    );
+
+    // Make v1
+    let conf = Config {
+        operator: Pubkey::new_unique(),
+        bump: 44,
+    };
+
+    // Cast to v2
+    let bytes = bytemuck::bytes_of(&conf);
+    let treasury: &Treasury = bytemuck::from_bytes(bytes);
+
+    // Verify the bump matches
+    assert_eq!(conf.bump, treasury.bump);
 }


### PR DESCRIPTION
**Summary of changes**

This PR ports https://github.com/eigerco/axelar-amplifier-solana/pull/295/ to v2 for CPI events. It also makes `Treasury` (previously `Config`) backwards compatible for easier migration of the gas service program.

**Reviewer recommendations**

Take a look at the v1 PR.