### PR TITLE
refactor: wrap spl token info in a struct

### DIFF
--- a/programs/axelar-solana-gas-service-v2/src/events.rs
+++ b/programs/axelar-solana-gas-service-v2/src/events.rs
@@ -9,6 +9,18 @@ use anchor_lang::prelude::{
 
 type MessageId = String;
 
+/// SPL Token information if payment was made with an SPL token
+/// Currently not supported
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, AnchorSerialize, AnchorDeserialize)]
+pub struct SplTokenInfo {
+    /// The mint of  the token
+    /// Token program can be derived from the mint owner
+    pub mint: Pubkey,
+    /// The token account used for the transaction
+    /// Either sender or receiver, depending on the event
+    pub token_account: Pubkey,
+}
+
 /// Event emitted by the Axelar Solana Gas service
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub enum GasServiceEvent {
@@ -38,15 +50,8 @@ pub struct GasPaidEvent {
     pub amount: u64,
     /// The refund address
     pub refund_address: Pubkey,
-    //
-    // SPL token fields
-    //
-    /// Mint of the token
-    pub mint: Option<Pubkey>,
-    /// Token program id
-    pub token_program_id: Option<Pubkey>,
-    /// Sender token account
-    pub sender_token_account: Option<Pubkey>,
+    /// Optional SPL token info
+    pub spl_token_info: Option<SplTokenInfo>,
 }
 
 /// Represents the event emitted when gas is added.
@@ -61,15 +66,8 @@ pub struct GasAddedEvent {
     pub amount: u64,
     /// The refund address
     pub refund_address: Pubkey,
-    //
-    // SPL token fields
-    //
-    /// Mint of the token
-    pub mint: Option<Pubkey>,
-    /// Token program id
-    pub token_program_id: Option<Pubkey>,
-    /// Sender token account
-    pub sender_token_account: Option<Pubkey>,
+    /// Optional SPL token info
+    pub spl_token_info: Option<SplTokenInfo>,
 }
 
 /// Represents the event emitted when gas is refunded.
@@ -82,15 +80,8 @@ pub struct GasRefundedEvent {
     pub message_id: MessageId,
     /// The amount of SOL refunded
     pub amount: u64,
-    //
-    // SPL token fields
-    //
-    /// Mint of the token
-    pub mint: Option<Pubkey>,
-    /// Token program id
-    pub token_program_id: Option<Pubkey>,
-    /// Receiver token account
-    pub receiver_token_account: Option<Pubkey>,
+    /// Optional SPL token info
+    pub spl_token_info: Option<SplTokenInfo>,
 }
 
 /// Represents the event emitted when accumulated gas is collected.
@@ -101,13 +92,6 @@ pub struct GasCollectedEvent {
     pub receiver: Pubkey,
     /// The amount of SOL refunded
     pub amount: u64,
-    //
-    // SPL token fields
-    //
-    /// Mint of the token
-    pub mint: Option<Pubkey>,
-    /// Token program id
-    pub token_program_id: Option<Pubkey>,
-    /// Receiver token account
-    pub receiver_token_account: Option<Pubkey>,
+    /// Optional SPL token info
+    pub spl_token_info: Option<SplTokenInfo>,
 }

--- a/programs/axelar-solana-gas-service-v2/src/instructions/add_gas.rs
+++ b/programs/axelar-solana-gas-service-v2/src/instructions/add_gas.rs
@@ -51,9 +51,7 @@ pub fn add_gas(
         message_id,
         amount,
         refund_address,
-        mint: None,
-        token_program_id: None,
-        sender_token_account: None,
+        spl_token_info: None,
     });
 
     Ok(())

--- a/programs/axelar-solana-gas-service-v2/src/instructions/collect_fees.rs
+++ b/programs/axelar-solana-gas-service-v2/src/instructions/collect_fees.rs
@@ -48,9 +48,7 @@ pub fn collect_native_fees(ctx: Context<CollectFees>, amount: u64) -> Result<()>
     emit_cpi!(GasCollectedEvent {
         receiver: ctx.accounts.receiver.key(),
         amount,
-        mint: None,
-        token_program_id: None,
-        receiver_token_account: None,
+        spl_token_info: None,
     });
 
     Ok(())

--- a/programs/axelar-solana-gas-service-v2/src/instructions/pay_gas.rs
+++ b/programs/axelar-solana-gas-service-v2/src/instructions/pay_gas.rs
@@ -55,9 +55,7 @@ pub fn pay_gas(
         payload_hash,
         amount,
         refund_address,
-        mint: None,
-        token_program_id: None,
-        sender_token_account: None,
+        spl_token_info: None,
     });
 
     Ok(())

--- a/programs/axelar-solana-gas-service-v2/src/instructions/refund_fees.rs
+++ b/programs/axelar-solana-gas-service-v2/src/instructions/refund_fees.rs
@@ -50,9 +50,7 @@ pub fn refund_native_fees(ctx: Context<RefundFees>, message_id: String, amount: 
         receiver: ctx.accounts.receiver.key(),
         message_id,
         amount,
-        mint: None,
-        token_program_id: None,
-        receiver_token_account: None,
+        spl_token_info: None,
     });
 
     Ok(())


### PR DESCRIPTION
**Summary of changes**

This PR addresses comments from #22. It removes the `token_program_id` which we can derive from the `mint` and wraps the remaining fields in an optional struct.