### PR TITLE
fix(its): box large accounts in InterchainTransfer to prevent stack overflow

### DIFF
--- a/.github/actions/setup-repo/action.yaml
+++ b/.github/actions/setup-repo/action.yaml
@@ -39,7 +39,7 @@ runs:
     - name: Install Solana
       shell: bash
       run: |
-        curl -sSfL https://release.anza.xyz/v2.2.14/install | sh
+        curl -sSfL https://release.anza.xyz/v3.1.12/install | sh
         echo "$HOME/.local/share/solana/install/active_release/bin" >> $GITHUB_PATH
 
     - name: Install needed tooling (needed for solana deps)

--- a/.github/actions/setup-repo/action.yaml
+++ b/.github/actions/setup-repo/action.yaml
@@ -39,7 +39,7 @@ runs:
     - name: Install Solana
       shell: bash
       run: |
-        curl -sSfL https://release.anza.xyz/v3.1.12/install | sh
+        curl -sSfL https://release.anza.xyz/stable/install | sh
         echo "$HOME/.local/share/solana/install/active_release/bin" >> $GITHUB_PATH
 
     - name: Install needed tooling (needed for solana deps)

--- a/programs/solana-axelar-its/src/instructions/gmp/interchain_transfer.rs
+++ b/programs/solana-axelar-its/src/instructions/gmp/interchain_transfer.rs
@@ -40,7 +40,7 @@ pub struct ExecuteInterchainTransfer<'info> {
         constraint = !its_root_pda.paused @ ItsError::Paused,
         signer, // important: only ITS can call this
     )]
-    pub its_root_pda: Account<'info, InterchainTokenService>,
+    pub its_root_pda: Box<Account<'info, InterchainTokenService>>,
 
     /// CHECK: we check this matches the destination address
     #[account(
@@ -80,7 +80,7 @@ pub struct ExecuteInterchainTransfer<'info> {
         constraint = token_manager_pda.token_address == token_mint.key()
             @ ItsError::TokenMintTokenManagerMissmatch
     )]
-    pub token_manager_pda: Account<'info, TokenManager>,
+    pub token_manager_pda: Box<Account<'info, TokenManager>>,
 
     #[account(
         mut,

--- a/programs/solana-axelar-its/src/instructions/interchain_token/interchain_transfer.rs
+++ b/programs/solana-axelar-its/src/instructions/interchain_token/interchain_transfer.rs
@@ -79,7 +79,7 @@ pub struct InterchainTransfer<'info> {
         constraint = its_root_pda.is_trusted_chain(&destination_chain)
             @ ItsError::UntrustedDestinationChain,
     )]
-    pub its_root_pda: Account<'info, InterchainTokenService>,
+    pub its_root_pda: Box<Account<'info, InterchainTokenService>>,
 
     #[account(
         mut,
@@ -91,7 +91,7 @@ pub struct InterchainTransfer<'info> {
         bump = token_manager_pda.bump,
         constraint = token_manager_pda.token_address == token_mint.key()  @ ItsError::TokenMintTokenManagerMissmatch
     )]
-    pub token_manager_pda: Account<'info, TokenManager>,
+    pub token_manager_pda: Box<Account<'info, TokenManager>>,
 
     //
     // Token Info


### PR DESCRIPTION
### why

Fixed the stack overflow issues, for example:

```
Error: A function call in method
ZN235_$LT$solana_axelar_its..instructions. interchain_token..interchain_transfer..Interchai nTransfer$u20$as$u20$anchor_lang..Accounts$LT$solana_axelar_its..instructions..interchain_to ken..interchain_transfer.. InterchainTransferBumps$GT$$GT$12try_accounts17hdd997879facf6e48E
overwrites values in the frame. Please, decrease stack usage or remove parameters from the call. The function call may cause undefined behavior during execution.
```

For some reason the tests were passing beforehand, but stopped passing when the . so files were being built by the latest solana-cli v3.

Fixes CPI-183

### how
<!-- An agent will fill this out -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches Solana on-chain instruction account context types (boxing `Account` fields) which can subtly affect deserialization/compute behavior at runtime, though intended as a memory/layout change only. CI also switches Solana install to `stable`, which may change build/test behavior across time.
> 
> **Overview**
> Updates the ITS interchain transfer instruction account contexts to **box large PDA accounts** (`its_root_pda`, `token_manager_pda`) in both inbound `ExecuteInterchainTransfer` and outbound `InterchainTransfer`, reducing stack usage to avoid stack overflows under newer Solana toolchains.
> 
> Separately, CI setup now installs Solana from the `stable` channel instead of pinning a specific `v2.2.14` release.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f12ebd29776f429bd588ede9e02799fd0cfd5b72. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->