### PR TITLE
ci: use GitHub App token in release workflows

### DIFF
--- a/.github/workflows/create-release-pr.yaml
+++ b/.github/workflows/create-release-pr.yaml
@@ -13,11 +13,18 @@ jobs:
     runs-on: blacksmith-8vcpu-ubuntu-2204
 
     steps:
+      - name: Generate GitHub token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        id: generate-token
+        with:
+          app-id: ${{ secrets.BOT_APP_ID }}
+          private-key: ${{ secrets.BOT_APP_PRIVATE_KEY }}
+
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          token: ${{ secrets.PAT_TOKEN }}
+          token: ${{ steps.generate-token.outputs.token }}
 
       - name: Run release-plz
         uses: MarcoIeni/release-plz-action@v0.5.82
@@ -25,5 +32,5 @@ jobs:
           command: release-pr
           version: "0.3.150"
         env:
-          GITHUB_TOKEN: ${{ secrets.PAT_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}

--- a/.github/workflows/pre-release.yaml
+++ b/.github/workflows/pre-release.yaml
@@ -69,7 +69,8 @@ jobs:
       cf-config-bucket-root-key: ${{ vars.CF_BUCKET_ROOT_KEY }}
       github-release: false
     secrets:
-      github-token: ${{ secrets.PAT_TOKEN }}
+      bot-app-id: ${{ secrets.BOT_APP_ID }}
+      bot-app-private-key: ${{ secrets.BOT_APP_PRIVATE_KEY }}
       cf-endpoint-url: ${{ secrets.CF_ENDPOINT_URL }}
       cf-bucket-access-key-id: ${{ secrets.CF_BUCKET_ACCESS_KEY_ID }}
       cf-bucket-secret-access-key: ${{ secrets.CF_BUCKET_SECRET_ACCESS_KEY }}

--- a/.github/workflows/release-dry-run.yaml
+++ b/.github/workflows/release-dry-run.yaml
@@ -14,10 +14,17 @@ jobs:
     runs-on: blacksmith-8vcpu-ubuntu-2204
 
     steps:
+      - name: Generate GitHub token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        id: generate-token
+        with:
+          app-id: ${{ secrets.BOT_APP_ID }}
+          private-key: ${{ secrets.BOT_APP_PRIVATE_KEY }}
+
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
-          token: ${{ secrets.PAT_TOKEN }}
+          token: ${{ steps.generate-token.outputs.token }}
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@1.86.0
@@ -30,7 +37,7 @@ jobs:
           version: "0.3.123"
         env:
           CARGO_NET_GIT_FETCH_WITH_CLI: true
-          GITHUB_TOKEN: ${{ secrets.PAT_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
 
       - name: Print dry-run results

--- a/.github/workflows/release-upload-to-r2.yaml
+++ b/.github/workflows/release-upload-to-r2.yaml
@@ -27,10 +27,17 @@ jobs:
       commit_hash: ${{ steps.get-commit-hash.outputs.hash }}
 
     steps:
+      - name: Generate GitHub token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        id: generate-token
+        with:
+          app-id: ${{ secrets.BOT_APP_ID }}
+          private-key: ${{ secrets.BOT_APP_PRIVATE_KEY }}
+
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
-          token: ${{ secrets.PAT_TOKEN }}
+          token: ${{ steps.generate-token.outputs.token }}
 
       - name: Prepare release matrix from input
         id: prepare-matrix
@@ -98,7 +105,8 @@ jobs:
       cf-config-bucket-root-key: ${{ vars.CF_BUCKET_ROOT_KEY }}
       github-release: true
     secrets:
-      github-token: ${{ secrets.PAT_TOKEN }}
+      bot-app-id: ${{ secrets.BOT_APP_ID }}
+      bot-app-private-key: ${{ secrets.BOT_APP_PRIVATE_KEY }}
       cf-endpoint-url: ${{ secrets.CF_ENDPOINT_URL }}
       cf-bucket-access-key-id: ${{ secrets.CF_BUCKET_ACCESS_KEY_ID }}
       cf-bucket-secret-access-key: ${{ secrets.CF_BUCKET_SECRET_ACCESS_KEY }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -19,10 +19,17 @@ jobs:
       commit_hash: ${{ steps.get-commit-hash.outputs.hash }}
 
     steps:
+      - name: Generate GitHub token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        id: generate-token
+        with:
+          app-id: ${{ secrets.BOT_APP_ID }}
+          private-key: ${{ secrets.BOT_APP_PRIVATE_KEY }}
+
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
-          token: ${{ secrets.PAT_TOKEN }}
+          token: ${{ steps.generate-token.outputs.token }}
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@1.86.0
@@ -39,7 +46,7 @@ jobs:
           version: "0.3.105"
         env:
           CARGO_NET_GIT_FETCH_WITH_CLI: true
-          GITHUB_TOKEN: ${{ secrets.PAT_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
 
       - name: Prepare JSON output to be a matrix GHA format
@@ -97,7 +104,8 @@ jobs:
       cf-config-bucket-root-key: ${{ vars.CF_BUCKET_ROOT_KEY }}
       github-release: true
     secrets:
-      github-token: ${{ secrets.PAT_TOKEN }}
+      bot-app-id: ${{ secrets.BOT_APP_ID }}
+      bot-app-private-key: ${{ secrets.BOT_APP_PRIVATE_KEY }}
       cf-endpoint-url: ${{ secrets.CF_ENDPOINT_URL }}
       cf-bucket-access-key-id: ${{ secrets.CF_BUCKET_ACCESS_KEY_ID }}
       cf-bucket-secret-access-key: ${{ secrets.CF_BUCKET_SECRET_ACCESS_KEY }}

--- a/.github/workflows/reusable-upload.yaml
+++ b/.github/workflows/reusable-upload.yaml
@@ -40,8 +40,11 @@ on:
         default: true
 
     secrets:
-      github-token:
-        description: "The github token to use to do the tag updates"
+      bot-app-id:
+        description: "The GitHub App ID used to generate a token for tag updates"
+        required: true
+      bot-app-private-key:
+        description: "The GitHub App private key used to generate a token for tag updates"
         required: true
       cf-endpoint-url:
         description: "The endpoint URL of the CF bucket"
@@ -208,6 +211,14 @@ jobs:
 
       # Update the existing release and upload the program binaries, zip and tar archives to the specific tag
       # https://github.com/orgs/community/discussions/26263#discussioncomment-3251069
+      - name: Generate GitHub token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        id: generate-token
+        if: inputs.github-release
+        with:
+          app-id: ${{ secrets.bot-app-id }}
+          private-key: ${{ secrets.bot-app-private-key }}
+
       - name: Update the GitHub Release
         uses: softprops/action-gh-release@c062e08bd532815e2082a85e87e3ef29c3e6d191 # v2.0.8
         if: inputs.github-release
@@ -215,4 +226,4 @@ jobs:
           tag_name: ${{ inputs.package-git-tag }} # This uses the tag from the push
           files: ${{ env.GITHUB_RELEASE_FILES }}
         env:
-          GITHUB_TOKEN: ${{ secrets.github-token }}
+          GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}


### PR DESCRIPTION
### why
Replace PAT_TOKEN with a short-lived token generated via the actions/create-github-app-token action. Same pattern as https://github.com/axelarnetwork/axelar-amplifier-stellar/pull/372.

Part of CPI-302

### how
<!-- An agent will fill this out -->


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how release automation authenticates to GitHub; misconfigured app secrets or permissions would break release PRs, publishing, or release asset uploads.
> 
> **Overview**
> Release and upload CI no longer use a long-lived **`PAT_TOKEN`**. Workflows that talk to GitHub (checkout, **release-plz**, and **softprops/action-gh-release**) now mint a short-lived token with **`actions/create-github-app-token`** from **`BOT_APP_ID`** / **`BOT_APP_PRIVATE_KEY`**.
> 
> Callers of **`reusable-upload`** pass **`bot-app-id`** and **`bot-app-private-key`** instead of **`github-token`**; the reusable workflow generates an app token only when **`github-release`** is true and uses it for release asset uploads.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a4309c9f4ba4703a2ee83ddb02d6ae7a2b8bd6e8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->