### PR TITLE
chore: bump anchor-lang to v1.0.2

### DIFF
--- a/.github/workflows/release-dry-run.yaml
+++ b/.github/workflows/release-dry-run.yaml
@@ -20,7 +20,7 @@ jobs:
           token: ${{ secrets.PAT_TOKEN }}
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@1.86.0
+        uses: dtolnay/rust-toolchain@1.87.0
 
       - name: Dry-run
         id: dry-run

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -25,7 +25,7 @@ jobs:
           token: ${{ secrets.PAT_TOKEN }}
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@1.86.0
+        uses: dtolnay/rust-toolchain@1.87.0
 
       - name: Get commit hash
         id: get-commit-hash

--- a/.github/workflows/reusable-build.yaml
+++ b/.github/workflows/reusable-build.yaml
@@ -30,7 +30,7 @@ jobs:
         run: git checkout ${{ inputs.commit-hash }}
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@1.86.0
+        uses: dtolnay/rust-toolchain@1.87.0
 
       - name: Set artifact name
         id: set-artifact-name

--- a/Anchor.toml
+++ b/Anchor.toml
@@ -1,6 +1,6 @@
 [toolchain]
 package_manager = "npm"
-anchor_version = "1.0.0"
+anchor_version = "1.0.2"
 
 [features]
 resolution = true

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -408,9 +408,9 @@ dependencies = [
 
 [[package]]
 name = "anchor-spl"
-version = "1.0.0"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "300e2e8058e674e8d6ea7c72dfb8be4349609dd9c3760ce729fc6406199624fe"
+checksum = "0b8005eef3a48a9a8cb21b126ae3bb252647e353afe6ef7f19e545177801c841"
 dependencies = [
  "anchor-lang",
  "spl-associated-token-account-interface",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -231,9 +231,9 @@ dependencies = [
 
 [[package]]
 name = "anchor-attribute-access-control"
-version = "1.0.0"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b972f5fbd02524c92e4eb487c3c648904572702670f3d6fc81aef5f1751b1569"
+checksum = "0b8cd233e382ea499e3c1e51bf4f0cb367abb37bb64e9e3667a5d618af3fe265"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -242,9 +242,9 @@ dependencies = [
 
 [[package]]
 name = "anchor-attribute-account"
-version = "1.0.0"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9acfcb07a92084bcfa9f6cc49a5c2e8e0e986f25f4b7caa184b7a2c9c9e561c2"
+checksum = "2e12171382e24c5cda6b0f7236a4f6bb9b657da997780c88a0ef794a419298bf"
 dependencies = [
  "anchor-syn",
  "proc-macro2",
@@ -254,9 +254,9 @@ dependencies = [
 
 [[package]]
 name = "anchor-attribute-constant"
-version = "1.0.0"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f46cc38f819377f07663b8eb492a701427950065e79d2d7b622a782443deb7a"
+checksum = "510f8db71375446405dfabdaf157fb7d3fbf33470c98ed75fad4c467e8ca0080"
 dependencies = [
  "anchor-syn",
  "quote",
@@ -265,9 +265,9 @@ dependencies = [
 
 [[package]]
 name = "anchor-attribute-error"
-version = "1.0.0"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c34748789107c9838329e058ca7b253e67f37b39ceae5a0a6c8d99f5d1bf1fe"
+checksum = "72b203169a49ea74da7782281e740ea8e21017c85f8f3b1ab452712c9796d28f"
 dependencies = [
  "anchor-syn",
  "quote",
@@ -276,9 +276,9 @@ dependencies = [
 
 [[package]]
 name = "anchor-attribute-event"
-version = "1.0.0"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a28a3e5eefa03d9c5ef02b2139198f652547d38dddafc9c5545152dfba54556"
+checksum = "c50a462651e573ec6cc632e8f607e8b1e11f620f6fc26badaeff04fd49f45cc1"
 dependencies = [
  "anchor-syn",
  "proc-macro2",
@@ -288,9 +288,9 @@ dependencies = [
 
 [[package]]
 name = "anchor-attribute-program"
-version = "1.0.0"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfaa03865053cb168bfc4debe5992be87f397aa027dd81b69a2e44f2e5bae1c5"
+checksum = "84704ee25a7e788afd9d846945cba536cfdcd53b463e8a337cf237cd897ca4d9"
 dependencies = [
  "anchor-lang-idl",
  "anchor-syn",
@@ -303,9 +303,9 @@ dependencies = [
 
 [[package]]
 name = "anchor-derive-accounts"
-version = "1.0.0"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eef330db08f9ceee45c18ef96b15b869883d280c0ab5c6ff5d2e2f6481da7911"
+checksum = "98bf49664527c7bb0ebca04e9b5bfb618d6ceb849ef44a8149241d244bbfb0f6"
 dependencies = [
  "anchor-syn",
  "quote",
@@ -314,9 +314,9 @@ dependencies = [
 
 [[package]]
 name = "anchor-derive-serde"
-version = "1.0.0"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0e80ff4e3ddb8c85aafd37926335c28f820516311e7106e5b7482b42e798aaa"
+checksum = "8140a40827bdfd74720f1f3084778fa081262f2f43bd4bdbc350f98ce1b341c6"
 dependencies = [
  "anchor-syn",
  "proc-macro-crate 3.4.0",
@@ -327,9 +327,9 @@ dependencies = [
 
 [[package]]
 name = "anchor-derive-space"
-version = "1.0.0"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2672af0ef4dfd5f5b6199355867b580cd8b4048093ef5208dd2b441305c15b8b"
+checksum = "1ee5b6fa5dde037399d3e0bb322a1c7360ad8adc6b6afdd797d19566c039dcfb"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -338,9 +338,9 @@ dependencies = [
 
 [[package]]
 name = "anchor-lang"
-version = "1.0.0"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8de9dce227fa0c08be20fef008c5b04681e1e0a15cb396e9619a9a1f800ff6cd"
+checksum = "1bac4de7c9a9a69180798af701e22302cc0ebf2ef683b843706a1b7809454735"
 dependencies = [
  "anchor-attribute-access-control",
  "anchor-attribute-account",
@@ -423,9 +423,9 @@ dependencies = [
 
 [[package]]
 name = "anchor-syn"
-version = "1.0.0"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c62f42cb7e348c033bd9bfba59979bcd66431c026ba23490af94045aa357a950"
+checksum = "6940253e80acf0f8e83b1ebd9c4772c496aedcce6ad19aa85ce75d0b6b188298"
 dependencies = [
  "anyhow",
  "bs58",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -110,7 +110,7 @@ unexpected_cfgs = { level = "warn", check-cfg = [
 
 
 [workspace.dependencies]
-anchor-lang = { version = "1.0.0", features = ["event-cpi"] }
+anchor-lang = { version = "1.0.2", features = ["event-cpi"] }
 anchor-spl = "1.0.0"
 alloy-primitives = "0.7"
 alloy-sol-types = "0.7"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ repository = "https://github.com/axelarnetwork/axelar-amplifier-solana"
 homepage = "https://github.com/axelarnetwork/axelar-amplifier-solana"
 license = "MIT/Apache-2.0"
 edition = "2021"
-rust-version = "1.86"
+rust-version = "1.87"
 
 [workspace.lints.clippy]
 cargo = { priority = -1, level = "deny" }
@@ -111,7 +111,7 @@ unexpected_cfgs = { level = "warn", check-cfg = [
 
 [workspace.dependencies]
 anchor-lang = { version = "1.0.2", features = ["event-cpi"] }
-anchor-spl = "1.0.0"
+anchor-spl = "1.0.2"
 alloy-primitives = "0.7"
 alloy-sol-types = "0.7"
 anyhow = "1"

--- a/programs/solana-axelar-governance/src/state/governance_config.rs
+++ b/programs/solana-axelar-governance/src/state/governance_config.rs
@@ -4,7 +4,7 @@ use crate::GovernanceError;
 use anchor_lang::prelude::*;
 
 pub type Hash = [u8; 32];
-/// The [`solana_program::pubkey::Pubkey`] bytes.
+/// The [`Pubkey`] bytes.
 pub type Address = [u8; 32];
 
 pub const VALID_PROPOSAL_DELAY_RANGE: RangeInclusive<u32> = 3600..=86400;

--- a/programs/solana-axelar-governance/src/state/proposal.rs
+++ b/programs/solana-axelar-governance/src/state/proposal.rs
@@ -62,8 +62,7 @@ impl ExecutableProposal {
 #[derive(Debug, Eq, PartialEq, Clone, AnchorSerialize, AnchorDeserialize)]
 pub struct ExecuteProposalData {
     /// The target program address for the proposal, represented as a 32-byte
-    /// array. Will be later converted to a [`solana_program::pubkey::Pubkey`].
-    /// [`solana_program::pubkey::Pubkey`] when executing the proposal.
+    /// array. Will be later converted to a [`Pubkey`] when executing the proposal.
     pub target_address: [u8; 32],
     /// The data required to call the target program.
     pub call_data: ExecuteProposalCallData,
@@ -94,12 +93,12 @@ pub struct ExecuteProposalCallData {
 
 #[derive(Debug, Eq, PartialEq, Clone, AnchorSerialize, AnchorDeserialize)]
 pub struct SolanaAccountMetadata {
-    /// The [`solana_program::pubkey::Pubkey`], converted to bytes.
+    /// The [`Pubkey`], converted to bytes.
     pub pubkey: [u8; 32],
     /// If this account is a signer of the transaction. See original
-    /// [`solana_program::instruction::AccountMeta::is_signer`].
+    /// `AccountMeta::is_signer`.
     pub is_signer: bool,
     /// If this account is writable. See original
-    /// [`solana_program::instruction::AccountMeta::is_writable`].
+    /// `AccountMeta::is_writable`.
     pub is_writable: bool,
 }

--- a/programs/solana-axelar-its/src/encoding.rs
+++ b/programs/solana-axelar-its/src/encoding.rs
@@ -8,7 +8,7 @@
 //! derives for IDL generation.
 //!
 //! WARNING: These mirrors must be kept in sync with the cosmwasm contract!
-//! https://github.com/axelarnetwork/axelar-amplifier/tree/main/contracts/its-borsh-translator
+//! <https://github.com/axelarnetwork/axelar-amplifier/tree/main/contracts/its-borsh-translator>
 
 use anchor_lang::prelude::*;
 

--- a/programs/solana-axelar-its/src/instructions/gmp/deploy_interchain_token.rs
+++ b/programs/solana-axelar-its/src/instructions/gmp/deploy_interchain_token.rs
@@ -204,8 +204,8 @@ pub fn process_inbound_deploy(
     Ok(())
 }
 
-fn create_token_metadata<'info>(
-    accounts: &ExecuteDeployInterchainToken<'info>,
+fn create_token_metadata(
+    accounts: &ExecuteDeployInterchainToken<'_>,
     name: &str,
     symbol: &str,
     token_id: [u8; 32],

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.86.0"
+channel = "1.87.0"


### PR DESCRIPTION
### why

fix for [RUSTSEC-2026-0144](https://rustsec.org/advisories/RUSTSEC-2026-0144.html)

### how
<!-- An agent will fill this out -->


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Dependency and toolchain bumps touch all Solana program builds and release CI; behavior should be unchanged aside from the security fix, but full rebuild/regression is warranted.
> 
> **Overview**
> Bumps **Anchor** from `1.0.0` to **`1.0.2`** across `Anchor.toml`, workspace `Cargo.toml` dependencies, and `Cargo.lock` (full `anchor-*` crate graph), addressing [RUSTSEC-2026-0144](https://rustsec.org/advisories/RUSTSEC-2026-0144.html).
> 
> Aligns the toolchain with that upgrade: **Rust `1.86` → `1.87`** in `rust-toolchain.toml`, `[workspace.package] rust-version`, and release/build GitHub Actions (`dtolnay/rust-toolchain@1.87.0`).
> 
> Small follow-on fixes: governance/ITS doc comments use `Pubkey` / `AccountMeta` instead of `solana_program::…` paths; ITS `create_token_metadata` drops an unused `'info` lifetime parameter; one doc URL is wrapped in angle brackets for rustdoc.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 74c68e69ce8818a1d314c0f12177dea429e00c79. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->