### PR TITLE
feat: add solidity solana libraries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,7 @@ bindings/generated/temp
 bindings/generated/dist
 bindings/solana-axelar-its-legacy/dist
 bindings/solana-axelar-its/dist
+
+
+evm-contracts/out
+evm-contracts/cache

--- a/evm-contracts/README.md
+++ b/evm-contracts/README.md
@@ -1,0 +1,173 @@
+# EVM Helpers
+
+Solidity helpers for constructing Axelar Solana executable payloads.
+
+The gateway payload is an envelope around application-specific bytes:
+
+```text
+[encoding scheme byte] [encoded execute payload and Solana account metadata]
+```
+
+The `executePayload` bytes are intentionally supplied by the caller. For simple
+programs they may be raw bytes. For programs that expect Borsh instruction data,
+use `BorshEncoding.sol` to build the inner payload.
+
+## Libraries
+
+- `src/SolanaGatewayPayload.sol`: encodes gateway executable payloads with either
+  ABI encoding or Borsh encoding.
+- `src/BorshEncoding.sol`: minimal Borsh primitive helpers for caller-owned
+  payload construction.
+
+## Encoding Schemes
+
+Borsh gateway payload:
+
+```text
+0x00
+u32_le executePayload.length
+executePayload bytes
+u32_le accounts.length
+account[0]
+account[1]
+...
+```
+
+Each account is:
+
+```text
+bytes32 pubkey
+uint8 flags
+```
+
+Flags:
+
+```text
+bit 0 = isSigner
+bit 1 = isWritable
+```
+
+ABI gateway payload:
+
+```text
+0x01 || abi.encode(bytes executePayload, SolanaAccountRepr[] accounts)
+```
+
+## Use With ITS
+
+When sending an interchain token transfer to a Solana program through EVM
+`InterchainTokenService.callContractWithInterchainToken`, pass the encoded
+gateway payload as the ITS `data` argument.
+
+```solidity
+// SPDX-License-Identifier: MIT OR Apache-2.0
+pragma solidity ^0.8.20;
+
+import {
+    SolanaAccountRepr,
+    SolanaGatewayPayload,
+    SolanaGatewayPayloadLib
+} from "./src/SolanaGatewayPayload.sol";
+
+interface IInterchainTokenService {
+    function callContractWithInterchainToken(
+        bytes32 tokenId,
+        string calldata destinationChain,
+        bytes calldata destinationAddress,
+        uint256 amount,
+        bytes memory data
+    ) external payable;
+}
+
+contract SendTokenToSolanaMemo {
+    using SolanaGatewayPayloadLib for SolanaGatewayPayload;
+
+    IInterchainTokenService public immutable its;
+
+    constructor(address its_) {
+        its = IInterchainTokenService(its_);
+    }
+
+    function send(
+        bytes32 tokenId,
+        bytes32 memoProgramId,
+        bytes32 memoCounterPda,
+        uint256 amount,
+        string calldata memo
+    ) external payable {
+        SolanaAccountRepr[] memory accounts = new SolanaAccountRepr[](1);
+        accounts[0] = SolanaGatewayPayloadLib.writable(memoCounterPda);
+
+        bytes memory data = SolanaGatewayPayload({
+            // The memo program reads raw UTF-8 bytes, not a Borsh string.
+            executePayload: bytes(memo),
+            accounts: accounts
+        }).encodeBorsh();
+
+        its.callContractWithInterchainToken{ value: msg.value }(
+            tokenId,
+            "solana",
+            abi.encodePacked(memoProgramId),
+            amount,
+            data
+        );
+    }
+}
+```
+
+For a destination program whose inner instruction data expects Borsh:
+
+```solidity
+import { BorshEncoding } from "./src/BorshEncoding.sol";
+import {
+    SolanaAccountRepr,
+    SolanaGatewayPayload,
+    SolanaGatewayPayloadLib
+} from "./src/SolanaGatewayPayload.sol";
+
+using SolanaGatewayPayloadLib for SolanaGatewayPayload;
+
+bytes memory executePayload = bytes.concat(
+    BorshEncoding.encodeU64(orderId),
+    BorshEncoding.encodeString(note)
+);
+
+SolanaAccountRepr[] memory accounts = new SolanaAccountRepr[](1);
+accounts[0] = SolanaGatewayPayloadLib.writable(userStatePda);
+
+bytes memory data = SolanaGatewayPayload({
+    executePayload: executePayload,
+    accounts: accounts
+}).encodeBorsh();
+```
+
+For the older ITS metadata API, wrap the same `data` with metadata version `0`:
+
+```solidity
+bytes memory metadata = bytes.concat(bytes4(0), data);
+```
+
+Then pass `metadata` to `interchainTransfer(..., metadata, gasValue)`.
+
+## Tests
+
+Run Solidity tests:
+
+```sh
+forge test
+```
+
+From the repository root, run the Rust compatibility fixture:
+
+```sh
+cargo test -p solana-axelar-gateway decodes_solidity_borsh_payload_fixture
+```
+
+The gateway Rust tests also include a generated compatibility check that runs
+Forge when available, emits the Solidity-encoded payload, and decodes that value
+in Rust. If Forge is not installed, the test prints a skip warning and returns
+success.
+
+```sh
+cargo test -p solana-axelar-gateway decodes_forge_generated_borsh_payload
+```

--- a/evm-contracts/README.md
+++ b/evm-contracts/README.md
@@ -12,6 +12,10 @@ The `executePayload` bytes are intentionally supplied by the caller. For simple
 programs they may be raw bytes. For programs that expect Borsh instruction data,
 use `BorshEncoding.sol` to build the inner payload.
 
+These helpers only produce protocol-encoded bytes. Callers are responsible for
+keeping the final payload and account list small enough for the intended Solana
+transaction, relayer, and destination-program execution path.
+
 ## Libraries
 
 - `src/SolanaGatewayPayload.sol`: encodes gateway executable payloads with either

--- a/evm-contracts/foundry.toml
+++ b/evm-contracts/foundry.toml
@@ -1,0 +1,8 @@
+[profile.default]
+src = "src"
+test = "test"
+out = "out"
+cache_path = "cache"
+solc_version = "0.8.28"
+optimizer = true
+optimizer_runs = 200

--- a/evm-contracts/src/BorshEncoding.sol
+++ b/evm-contracts/src/BorshEncoding.sol
@@ -57,12 +57,16 @@ library BorshEncoding {
         return encodeBytes(bytes(value));
     }
 
-    function encodeOptionBytes(bytes memory value, bool isSome) internal pure returns (bytes memory) {
-        return isSome ? bytes.concat(bytes1(uint8(1)), encodeBytes(value)) : abi.encodePacked(bytes1(uint8(0)));
+    function encodeSomeBytes(bytes memory value) internal pure returns (bytes memory) {
+        return bytes.concat(bytes1(uint8(1)), encodeBytes(value));
     }
 
-    function encodeOptionString(string memory value, bool isSome) internal pure returns (bytes memory) {
-        return isSome ? bytes.concat(bytes1(uint8(1)), encodeString(value)) : abi.encodePacked(bytes1(uint8(0)));
+    function encodeSomeString(string memory value) internal pure returns (bytes memory) {
+        return bytes.concat(bytes1(uint8(1)), encodeString(value));
+    }
+
+    function encodeNone() internal pure returns (bytes memory) {
+        return abi.encodePacked(bytes1(uint8(0)));
     }
 
     function appendU8(bytes memory buffer, uint8 value) internal pure returns (bytes memory) {

--- a/evm-contracts/src/BorshEncoding.sol
+++ b/evm-contracts/src/BorshEncoding.sol
@@ -1,0 +1,104 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+pragma solidity ^0.8.20;
+
+/// @notice Minimal Borsh encoding helpers for building Solana instruction payloads.
+/// @dev This is intentionally not a full schema system. Callers remain responsible
+///      for matching the destination program's exact Borsh layout.
+library BorshEncoding {
+    error LengthOverflow();
+
+    function encodeU8(uint8 value) internal pure returns (bytes memory) {
+        return abi.encodePacked(value);
+    }
+
+    function encodeU16(uint16 value) internal pure returns (bytes memory) {
+        return abi.encodePacked(bytes1(uint8(value)), bytes1(uint8(value >> 8)));
+    }
+
+    function encodeU32(uint32 value) internal pure returns (bytes memory) {
+        return abi.encodePacked(
+            bytes1(uint8(value)), bytes1(uint8(value >> 8)), bytes1(uint8(value >> 16)), bytes1(uint8(value >> 24))
+        );
+    }
+
+    function encodeU64(uint64 value) internal pure returns (bytes memory) {
+        return abi.encodePacked(
+            bytes1(uint8(value)),
+            bytes1(uint8(value >> 8)),
+            bytes1(uint8(value >> 16)),
+            bytes1(uint8(value >> 24)),
+            bytes1(uint8(value >> 32)),
+            bytes1(uint8(value >> 40)),
+            bytes1(uint8(value >> 48)),
+            bytes1(uint8(value >> 56))
+        );
+    }
+
+    function encodeU128(uint128 value) internal pure returns (bytes memory encoded) {
+        encoded = new bytes(16);
+        for (uint256 i; i < 16; ++i) {
+            encoded[i] = bytes1(uint8(value >> (i * 8)));
+        }
+    }
+
+    function encodeBool(bool value) internal pure returns (bytes memory) {
+        return abi.encodePacked(value ? bytes1(uint8(1)) : bytes1(uint8(0)));
+    }
+
+    function encodeFixedBytes32(bytes32 value) internal pure returns (bytes memory) {
+        return abi.encodePacked(value);
+    }
+
+    function encodeBytes(bytes memory value) internal pure returns (bytes memory) {
+        return bytes.concat(encodeLength(value.length), value);
+    }
+
+    function encodeString(string memory value) internal pure returns (bytes memory) {
+        return encodeBytes(bytes(value));
+    }
+
+    function encodeOptionBytes(bytes memory value, bool isSome) internal pure returns (bytes memory) {
+        return isSome ? bytes.concat(bytes1(uint8(1)), encodeBytes(value)) : abi.encodePacked(bytes1(uint8(0)));
+    }
+
+    function encodeOptionString(string memory value, bool isSome) internal pure returns (bytes memory) {
+        return isSome ? bytes.concat(bytes1(uint8(1)), encodeString(value)) : abi.encodePacked(bytes1(uint8(0)));
+    }
+
+    function appendU8(bytes memory buffer, uint8 value) internal pure returns (bytes memory) {
+        return bytes.concat(buffer, encodeU8(value));
+    }
+
+    function appendU16(bytes memory buffer, uint16 value) internal pure returns (bytes memory) {
+        return bytes.concat(buffer, encodeU16(value));
+    }
+
+    function appendU32(bytes memory buffer, uint32 value) internal pure returns (bytes memory) {
+        return bytes.concat(buffer, encodeU32(value));
+    }
+
+    function appendU64(bytes memory buffer, uint64 value) internal pure returns (bytes memory) {
+        return bytes.concat(buffer, encodeU64(value));
+    }
+
+    function appendU128(bytes memory buffer, uint128 value) internal pure returns (bytes memory) {
+        return bytes.concat(buffer, encodeU128(value));
+    }
+
+    function appendBool(bytes memory buffer, bool value) internal pure returns (bytes memory) {
+        return bytes.concat(buffer, encodeBool(value));
+    }
+
+    function appendBytes(bytes memory buffer, bytes memory value) internal pure returns (bytes memory) {
+        return bytes.concat(buffer, encodeBytes(value));
+    }
+
+    function appendString(bytes memory buffer, string memory value) internal pure returns (bytes memory) {
+        return bytes.concat(buffer, encodeString(value));
+    }
+
+    function encodeLength(uint256 length) internal pure returns (bytes memory) {
+        if (length > type(uint32).max) revert LengthOverflow();
+        return encodeU32(uint32(length));
+    }
+}

--- a/evm-contracts/src/SolanaGatewayPayload.sol
+++ b/evm-contracts/src/SolanaGatewayPayload.sol
@@ -1,13 +1,13 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 pragma solidity ^0.8.20;
 
-import {BorshEncoding} from "./BorshEncoding.sol";
-
 using SolanaGatewayPayloadLib for SolanaGatewayPayload global;
 
 /// @notice Represents a payload that can be executed on Solana via the Axelar gateway.
 /// @dev `executePayload` is destination-program-specific. This library only wraps it
-///      with the gateway encoding scheme and Solana account metadata.
+///      with the gateway encoding scheme and Solana account metadata. Encoded bytes
+///      can still exceed Solana transaction or route-specific message limits; callers
+///      are responsible for keeping payload and account sizes executable.
 struct SolanaGatewayPayload {
     bytes executePayload;
     SolanaAccountRepr[] accounts;
@@ -26,10 +26,12 @@ enum SolanaGatewayEncoding {
 }
 
 library SolanaGatewayPayloadLib {
+    // Must stay in sync with programs/solana-axelar-gateway/src/payload/encoding.rs.
     uint8 internal constant BORSH_SCHEME = 0;
     uint8 internal constant ABI_SCHEME = 1;
 
     error InvalidEncoding();
+    error PayloadLengthOverflow();
     error AccountLengthOverflow();
 
     function encode(SolanaGatewayPayload memory payload, SolanaGatewayEncoding encoding)
@@ -47,20 +49,28 @@ library SolanaGatewayPayloadLib {
     }
 
     function encodeAbi(SolanaGatewayPayload memory payload) internal pure returns (bytes memory) {
+        // Rust decodes ABI payloads as tuple params, matching `abi.encode(bytes, accounts)`.
+        // Do not replace with `abi.encode(payload)`, which encodes a single struct param.
         return abi.encodePacked(bytes1(ABI_SCHEME), abi.encode(payload.executePayload, payload.accounts));
     }
 
     function encodeBorsh(SolanaGatewayPayload memory payload) internal pure returns (bytes memory encoded) {
+        if (payload.executePayload.length > type(uint32).max) revert PayloadLengthOverflow();
         if (payload.accounts.length > type(uint32).max) revert AccountLengthOverflow();
 
-        encoded = bytes.concat(
-            bytes1(BORSH_SCHEME),
-            BorshEncoding.encodeBytes(payload.executePayload),
-            BorshEncoding.encodeU32(uint32(payload.accounts.length))
-        );
+        encoded = new bytes(1 + 4 + payload.executePayload.length + 4 + payload.accounts.length * 33);
 
+        uint256 offset;
+        encoded[offset++] = bytes1(BORSH_SCHEME);
+
+        offset = writeU32(encoded, offset, uint32(payload.executePayload.length));
+        for (uint256 i; i < payload.executePayload.length; ++i) {
+            encoded[offset++] = payload.executePayload[i];
+        }
+
+        offset = writeU32(encoded, offset, uint32(payload.accounts.length));
         for (uint256 i; i < payload.accounts.length; ++i) {
-            encoded = bytes.concat(encoded, encodeAccountBorsh(payload.accounts[i]));
+            offset = writeAccountBorsh(encoded, offset, payload.accounts[i]);
         }
     }
 
@@ -94,5 +104,25 @@ library SolanaGatewayPayloadLib {
             flags |= 2;
         }
         return bytes1(flags);
+    }
+
+    function writeU32(bytes memory buffer, uint256 offset, uint32 value) private pure returns (uint256) {
+        buffer[offset++] = bytes1(uint8(value));
+        buffer[offset++] = bytes1(uint8(value >> 8));
+        buffer[offset++] = bytes1(uint8(value >> 16));
+        buffer[offset++] = bytes1(uint8(value >> 24));
+        return offset;
+    }
+
+    function writeAccountBorsh(bytes memory buffer, uint256 offset, SolanaAccountRepr memory accountRepr)
+        private
+        pure
+        returns (uint256)
+    {
+        for (uint256 i; i < 32; ++i) {
+            buffer[offset++] = accountRepr.pubkey[i];
+        }
+        buffer[offset++] = accountFlags(accountRepr);
+        return offset;
     }
 }

--- a/evm-contracts/src/SolanaGatewayPayload.sol
+++ b/evm-contracts/src/SolanaGatewayPayload.sol
@@ -1,0 +1,98 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+pragma solidity ^0.8.20;
+
+import {BorshEncoding} from "./BorshEncoding.sol";
+
+using SolanaGatewayPayloadLib for SolanaGatewayPayload global;
+
+/// @notice Represents a payload that can be executed on Solana via the Axelar gateway.
+/// @dev `executePayload` is destination-program-specific. This library only wraps it
+///      with the gateway encoding scheme and Solana account metadata.
+struct SolanaGatewayPayload {
+    bytes executePayload;
+    SolanaAccountRepr[] accounts;
+}
+
+/// @notice Representation of a Solana account meta used by executable payloads.
+struct SolanaAccountRepr {
+    bytes32 pubkey;
+    bool isSigner;
+    bool isWritable;
+}
+
+enum SolanaGatewayEncoding {
+    Borsh,
+    Abi
+}
+
+library SolanaGatewayPayloadLib {
+    uint8 internal constant BORSH_SCHEME = 0;
+    uint8 internal constant ABI_SCHEME = 1;
+
+    error InvalidEncoding();
+    error AccountLengthOverflow();
+
+    function encode(SolanaGatewayPayload memory payload, SolanaGatewayEncoding encoding)
+        internal
+        pure
+        returns (bytes memory)
+    {
+        if (encoding == SolanaGatewayEncoding.Borsh) {
+            return encodeBorsh(payload);
+        }
+        if (encoding == SolanaGatewayEncoding.Abi) {
+            return encodeAbi(payload);
+        }
+        revert InvalidEncoding();
+    }
+
+    function encodeAbi(SolanaGatewayPayload memory payload) internal pure returns (bytes memory) {
+        return abi.encodePacked(bytes1(ABI_SCHEME), abi.encode(payload.executePayload, payload.accounts));
+    }
+
+    function encodeBorsh(SolanaGatewayPayload memory payload) internal pure returns (bytes memory encoded) {
+        if (payload.accounts.length > type(uint32).max) revert AccountLengthOverflow();
+
+        encoded = bytes.concat(
+            bytes1(BORSH_SCHEME),
+            BorshEncoding.encodeBytes(payload.executePayload),
+            BorshEncoding.encodeU32(uint32(payload.accounts.length))
+        );
+
+        for (uint256 i; i < payload.accounts.length; ++i) {
+            encoded = bytes.concat(encoded, encodeAccountBorsh(payload.accounts[i]));
+        }
+    }
+
+    function payloadHash(bytes memory encodedPayload) internal pure returns (bytes32) {
+        return keccak256(encodedPayload);
+    }
+
+    function account(bytes32 pubkey, bool isSigner, bool isWritable) internal pure returns (SolanaAccountRepr memory) {
+        return SolanaAccountRepr({pubkey: pubkey, isSigner: isSigner, isWritable: isWritable});
+    }
+
+    function readonly(bytes32 pubkey) internal pure returns (SolanaAccountRepr memory) {
+        return account(pubkey, false, false);
+    }
+
+    function writable(bytes32 pubkey) internal pure returns (SolanaAccountRepr memory) {
+        return account(pubkey, false, true);
+    }
+
+    function signer(bytes32 pubkey, bool isWritable) internal pure returns (SolanaAccountRepr memory) {
+        return account(pubkey, true, isWritable);
+    }
+
+    function encodeAccountBorsh(SolanaAccountRepr memory accountRepr) internal pure returns (bytes memory) {
+        return abi.encodePacked(accountRepr.pubkey, accountFlags(accountRepr));
+    }
+
+    function accountFlags(SolanaAccountRepr memory accountRepr) internal pure returns (bytes1) {
+        uint8 flags = accountRepr.isSigner ? 1 : 0;
+        if (accountRepr.isWritable) {
+            flags |= 2;
+        }
+        return bytes1(flags);
+    }
+}

--- a/evm-contracts/src/SolanaGatewayPayload.sol
+++ b/evm-contracts/src/SolanaGatewayPayload.sol
@@ -58,6 +58,8 @@ library SolanaGatewayPayloadLib {
         if (payload.executePayload.length > type(uint32).max) revert PayloadLengthOverflow();
         if (payload.accounts.length > type(uint32).max) revert AccountLengthOverflow();
 
+        // TODO: Optimize gas further by copying payload bytes and account pubkeys in 32-byte
+        // chunks. This avoids O(n^2) buffer growth, but still writes byte-by-byte.
         encoded = new bytes(1 + 4 + payload.executePayload.length + 4 + payload.accounts.length * 33);
 
         uint256 offset;

--- a/evm-contracts/test/BorshEncoding.t.sol
+++ b/evm-contracts/test/BorshEncoding.t.sol
@@ -1,0 +1,95 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+pragma solidity ^0.8.20;
+
+import {BorshEncoding} from "../src/BorshEncoding.sol";
+
+contract BorshEncodingTest {
+    function testIntegerEncodingIsLittleEndian() public pure {
+        assertBytesEq(BorshEncoding.encodeU8(0x12), hex"12");
+        assertBytesEq(BorshEncoding.encodeU16(0x1234), hex"3412");
+        assertBytesEq(BorshEncoding.encodeU32(0x12345678), hex"78563412");
+        assertBytesEq(BorshEncoding.encodeU64(0x0102030405060708), hex"0807060504030201");
+        assertBytesEq(
+            BorshEncoding.encodeU128(0x0102030405060708090a0b0c0d0e0f10), hex"100f0e0d0c0b0a090807060504030201"
+        );
+    }
+
+    function testBoolBytesStringAndOptions() public pure {
+        assertBytesEq(BorshEncoding.encodeBool(true), hex"01");
+        assertBytesEq(BorshEncoding.encodeBool(false), hex"00");
+        assertBytesEq(BorshEncoding.encodeBytes(hex"aabbcc"), hex"03000000aabbcc");
+        assertBytesEq(BorshEncoding.encodeString("memo"), hex"040000006d656d6f");
+        assertBytesEq(BorshEncoding.encodeOptionBytes(hex"aabb", true), hex"0102000000aabb");
+        assertBytesEq(BorshEncoding.encodeOptionBytes(hex"aabb", false), hex"00");
+        assertBytesEq(BorshEncoding.encodeOptionString("hi", true), hex"01020000006869");
+        assertBytesEq(BorshEncoding.encodeOptionString("hi", false), hex"00");
+    }
+
+    function testAppendHelpers() public pure {
+        bytes memory encoded = hex"99";
+        encoded = BorshEncoding.appendU32(encoded, 2);
+        encoded = BorshEncoding.appendString(encoded, "ok");
+        encoded = BorshEncoding.appendBool(encoded, true);
+
+        assertBytesEq(encoded, hex"9902000000020000006f6b01");
+    }
+
+    function testFuzzU32EncodingMatchesLittleEndian(uint32 value) public pure {
+        bytes memory encoded = BorshEncoding.encodeU32(value);
+
+        require(encoded.length == 4, "bad u32 length");
+        require(uint8(encoded[0]) == uint8(value), "bad u32 byte 0");
+        require(uint8(encoded[1]) == uint8(value >> 8), "bad u32 byte 1");
+        require(uint8(encoded[2]) == uint8(value >> 16), "bad u32 byte 2");
+        require(uint8(encoded[3]) == uint8(value >> 24), "bad u32 byte 3");
+    }
+
+    function testFuzzU64EncodingMatchesLittleEndian(uint64 value) public pure {
+        bytes memory encoded = BorshEncoding.encodeU64(value);
+
+        require(encoded.length == 8, "bad u64 length");
+        for (uint256 i; i < 8; ++i) {
+            require(uint8(encoded[i]) == uint8(value >> (i * 8)), "bad u64 byte");
+        }
+    }
+
+    function testFuzzU128EncodingMatchesLittleEndian(uint128 value) public pure {
+        bytes memory encoded = BorshEncoding.encodeU128(value);
+
+        require(encoded.length == 16, "bad u128 length");
+        for (uint256 i; i < 16; ++i) {
+            require(uint8(encoded[i]) == uint8(value >> (i * 8)), "bad u128 byte");
+        }
+    }
+
+    function testFuzzBytesEncoding(bytes memory value) public pure {
+        if (value.length > 512) return;
+
+        bytes memory encoded = BorshEncoding.encodeBytes(value);
+
+        require(encoded.length == value.length + 4, "bad bytes length");
+        assertBytesEq(slice(encoded, 0, 4), BorshEncoding.encodeU32(uint32(value.length)));
+        assertBytesEq(slice(encoded, 4, value.length), value);
+    }
+
+    function testFuzzAppendEqualsConcat(bytes memory prefix, uint32 value, string memory text) public pure {
+        if (prefix.length > 256 || bytes(text).length > 256) return;
+
+        bytes memory appended = BorshEncoding.appendString(BorshEncoding.appendU32(prefix, value), text);
+        bytes memory expected = bytes.concat(prefix, BorshEncoding.encodeU32(value), BorshEncoding.encodeString(text));
+
+        assertBytesEq(appended, expected);
+    }
+
+    function slice(bytes memory input, uint256 start, uint256 length) private pure returns (bytes memory output) {
+        require(input.length >= start + length, "slice out of bounds");
+        output = new bytes(length);
+        for (uint256 i; i < length; ++i) {
+            output[i] = input[start + i];
+        }
+    }
+
+    function assertBytesEq(bytes memory actual, bytes memory expected) private pure {
+        require(keccak256(actual) == keccak256(expected), "bytes mismatch");
+    }
+}

--- a/evm-contracts/test/BorshEncoding.t.sol
+++ b/evm-contracts/test/BorshEncoding.t.sol
@@ -19,10 +19,9 @@ contract BorshEncodingTest {
         assertBytesEq(BorshEncoding.encodeBool(false), hex"00");
         assertBytesEq(BorshEncoding.encodeBytes(hex"aabbcc"), hex"03000000aabbcc");
         assertBytesEq(BorshEncoding.encodeString("memo"), hex"040000006d656d6f");
-        assertBytesEq(BorshEncoding.encodeOptionBytes(hex"aabb", true), hex"0102000000aabb");
-        assertBytesEq(BorshEncoding.encodeOptionBytes(hex"aabb", false), hex"00");
-        assertBytesEq(BorshEncoding.encodeOptionString("hi", true), hex"01020000006869");
-        assertBytesEq(BorshEncoding.encodeOptionString("hi", false), hex"00");
+        assertBytesEq(BorshEncoding.encodeSomeBytes(hex"aabb"), hex"0102000000aabb");
+        assertBytesEq(BorshEncoding.encodeSomeString("hi"), hex"01020000006869");
+        assertBytesEq(BorshEncoding.encodeNone(), hex"00");
     }
 
     function testAppendHelpers() public pure {

--- a/evm-contracts/test/SolanaGatewayPayload.t.sol
+++ b/evm-contracts/test/SolanaGatewayPayload.t.sol
@@ -1,0 +1,173 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+pragma solidity ^0.8.20;
+
+import {
+    SolanaAccountRepr,
+    SolanaGatewayEncoding,
+    SolanaGatewayPayload,
+    SolanaGatewayPayloadLib
+} from "../src/SolanaGatewayPayload.sol";
+
+contract SolanaGatewayPayloadTest {
+    using SolanaGatewayPayloadLib for SolanaGatewayPayload;
+
+    event EncodedBorshPayload(bytes payload);
+
+    function testBorshEncodingEmptyPayloadAndAccounts() public pure {
+        SolanaAccountRepr[] memory accounts = new SolanaAccountRepr[](0);
+        bytes memory encoded = SolanaGatewayPayload({executePayload: "", accounts: accounts}).encodeBorsh();
+
+        assertBytesEq(encoded, hex"000000000000000000");
+    }
+
+    function testBorshEncodingPayloadAndAccountFlags() public pure {
+        SolanaAccountRepr[] memory accounts = new SolanaAccountRepr[](4);
+        accounts[0] = SolanaGatewayPayloadLib.account(bytes32(uint256(0x1111)), true, true);
+        accounts[1] = SolanaGatewayPayloadLib.signer(bytes32(uint256(0x2222)), false);
+        accounts[2] = SolanaGatewayPayloadLib.writable(bytes32(uint256(0x3333)));
+        accounts[3] = SolanaGatewayPayloadLib.readonly(bytes32(uint256(0x4444)));
+
+        bytes memory encoded = SolanaGatewayPayload({executePayload: hex"010203", accounts: accounts}).encodeBorsh();
+
+        bytes memory expected = bytes.concat(
+            hex"00",
+            hex"03000000",
+            hex"010203",
+            hex"04000000",
+            bytes32(uint256(0x1111)),
+            hex"03",
+            bytes32(uint256(0x2222)),
+            hex"01",
+            bytes32(uint256(0x3333)),
+            hex"02",
+            bytes32(uint256(0x4444)),
+            hex"00"
+        );
+
+        assertBytesEq(encoded, expected);
+    }
+
+    function testAbiEncodingCanBeDecodedAfterSchemeByte() public pure {
+        SolanaAccountRepr[] memory accounts = new SolanaAccountRepr[](2);
+        accounts[0] = SolanaGatewayPayloadLib.writable(bytes32(uint256(0xaaaa)));
+        accounts[1] = SolanaGatewayPayloadLib.signer(bytes32(uint256(0xbbbb)), true);
+
+        bytes memory encoded = SolanaGatewayPayload({executePayload: hex"cafe", accounts: accounts}).encodeAbi();
+        require(uint8(encoded[0]) == 1, "bad scheme");
+
+        (bytes memory executePayload, SolanaAccountRepr[] memory decodedAccounts) =
+            abi.decode(skipSchemeByte(encoded), (bytes, SolanaAccountRepr[]));
+
+        assertBytesEq(executePayload, hex"cafe");
+        require(decodedAccounts.length == 2, "bad account length");
+        require(decodedAccounts[0].pubkey == bytes32(uint256(0xaaaa)), "bad account 0 pubkey");
+        require(!decodedAccounts[0].isSigner, "bad account 0 signer");
+        require(decodedAccounts[0].isWritable, "bad account 0 writable");
+        require(decodedAccounts[1].pubkey == bytes32(uint256(0xbbbb)), "bad account 1 pubkey");
+        require(decodedAccounts[1].isSigner, "bad account 1 signer");
+        require(decodedAccounts[1].isWritable, "bad account 1 writable");
+    }
+
+    function testGenericEncodeAndPayloadHash() public pure {
+        SolanaAccountRepr[] memory accounts = new SolanaAccountRepr[](1);
+        accounts[0] = SolanaGatewayPayloadLib.readonly(bytes32(uint256(0x1234)));
+
+        SolanaGatewayPayload memory payload = SolanaGatewayPayload({executePayload: bytes("memo"), accounts: accounts});
+
+        bytes memory borshEncoded = payload.encode(SolanaGatewayEncoding.Borsh);
+        bytes memory abiEncoded = payload.encode(SolanaGatewayEncoding.Abi);
+
+        require(uint8(borshEncoded[0]) == 0, "bad borsh scheme");
+        require(uint8(abiEncoded[0]) == 1, "bad abi scheme");
+        require(SolanaGatewayPayloadLib.payloadHash(borshEncoded) == keccak256(borshEncoded), "bad hash");
+    }
+
+    function testEmitBorshPayloadForRustCompatibility() public {
+        SolanaAccountRepr[] memory accounts = new SolanaAccountRepr[](4);
+        accounts[0] = SolanaGatewayPayloadLib.account(bytes32(uint256(0x1111)), true, true);
+        accounts[1] = SolanaGatewayPayloadLib.signer(bytes32(uint256(0x2222)), false);
+        accounts[2] = SolanaGatewayPayloadLib.writable(bytes32(uint256(0x3333)));
+        accounts[3] = SolanaGatewayPayloadLib.readonly(bytes32(uint256(0x4444)));
+
+        bytes memory encoded = SolanaGatewayPayload({executePayload: hex"010203", accounts: accounts}).encodeBorsh();
+
+        emit EncodedBorshPayload(encoded);
+    }
+
+    function testFuzzBorshEncodingSingleAccount(
+        bytes memory executePayload,
+        bytes32 pubkey,
+        bool isSigner,
+        bool isWritable
+    ) public pure {
+        if (executePayload.length > 512) return;
+
+        SolanaAccountRepr[] memory accounts = new SolanaAccountRepr[](1);
+        accounts[0] = SolanaGatewayPayloadLib.account(pubkey, isSigner, isWritable);
+
+        bytes memory encoded = SolanaGatewayPayload({executePayload: executePayload, accounts: accounts}).encodeBorsh();
+        bytes memory expected = bytes.concat(
+            hex"00",
+            le32(uint32(executePayload.length)),
+            executePayload,
+            le32(1),
+            pubkey,
+            bytes1((isSigner ? uint8(1) : uint8(0)) | (isWritable ? uint8(2) : uint8(0)))
+        );
+
+        assertBytesEq(encoded, expected);
+    }
+
+    function testFuzzAbiEncodingRoundTrip(bytes memory executePayload, bytes32 pubkey, bool isSigner, bool isWritable)
+        public
+        pure
+    {
+        if (executePayload.length > 512) return;
+
+        SolanaAccountRepr[] memory accounts = new SolanaAccountRepr[](1);
+        accounts[0] = SolanaGatewayPayloadLib.account(pubkey, isSigner, isWritable);
+
+        bytes memory encoded = SolanaGatewayPayload({executePayload: executePayload, accounts: accounts}).encodeAbi();
+
+        require(uint8(encoded[0]) == 1, "bad scheme");
+
+        (bytes memory decodedPayload, SolanaAccountRepr[] memory decodedAccounts) =
+            abi.decode(skipSchemeByte(encoded), (bytes, SolanaAccountRepr[]));
+
+        assertBytesEq(decodedPayload, executePayload);
+        require(decodedAccounts.length == 1, "bad account length");
+        require(decodedAccounts[0].pubkey == pubkey, "bad pubkey");
+        require(decodedAccounts[0].isSigner == isSigner, "bad signer");
+        require(decodedAccounts[0].isWritable == isWritable, "bad writable");
+    }
+
+    function testFuzzGenericEncodeDispatch(bytes memory executePayload, bytes32 pubkey) public pure {
+        if (executePayload.length > 512) return;
+
+        SolanaAccountRepr[] memory accounts = new SolanaAccountRepr[](1);
+        accounts[0] = SolanaGatewayPayloadLib.writable(pubkey);
+
+        SolanaGatewayPayload memory payload = SolanaGatewayPayload({executePayload: executePayload, accounts: accounts});
+
+        assertBytesEq(payload.encode(SolanaGatewayEncoding.Borsh), payload.encodeBorsh());
+        assertBytesEq(payload.encode(SolanaGatewayEncoding.Abi), payload.encodeAbi());
+    }
+
+    function le32(uint32 value) private pure returns (bytes memory) {
+        return abi.encodePacked(
+            bytes1(uint8(value)), bytes1(uint8(value >> 8)), bytes1(uint8(value >> 16)), bytes1(uint8(value >> 24))
+        );
+    }
+
+    function skipSchemeByte(bytes memory input) private pure returns (bytes memory output) {
+        require(input.length > 0, "empty input");
+        output = new bytes(input.length - 1);
+        for (uint256 i; i < output.length; ++i) {
+            output[i] = input[i + 1];
+        }
+    }
+
+    function assertBytesEq(bytes memory actual, bytes memory expected) private pure {
+        require(keccak256(actual) == keccak256(expected), "bytes mismatch");
+    }
+}

--- a/evm-contracts/test/SolanaGatewayPayload.t.sol
+++ b/evm-contracts/test/SolanaGatewayPayload.t.sol
@@ -118,6 +118,44 @@ contract SolanaGatewayPayloadTest {
         assertBytesEq(encoded, expected);
     }
 
+    function testFuzzBorshEncodingMultipleAccounts(
+        bytes memory executePayload,
+        bytes32[16] memory pubkeys,
+        uint16 signerMask,
+        uint16 writableMask,
+        uint8 accountCount
+    ) public pure {
+        if (executePayload.length > 512) return;
+        accountCount = uint8(bound(accountCount, 0, 16));
+
+        SolanaAccountRepr[] memory accounts = new SolanaAccountRepr[](accountCount);
+        for (uint256 i; i < accountCount; ++i) {
+            accounts[i] = SolanaGatewayPayloadLib.account(
+                pubkeys[i], ((signerMask >> i) & 1) == 1, ((writableMask >> i) & 1) == 1
+            );
+        }
+
+        bytes memory encoded = SolanaGatewayPayload({executePayload: executePayload, accounts: accounts}).encodeBorsh();
+
+        require(encoded.length == 1 + 4 + executePayload.length + 4 + uint256(accountCount) * 33, "bad encoded length");
+        require(uint8(encoded[0]) == 0, "bad scheme");
+        assertBytesEq(slice(encoded, 1, 4), le32(uint32(executePayload.length)));
+        assertBytesEq(slice(encoded, 5, executePayload.length), executePayload);
+
+        uint256 accountsOffset = 5 + executePayload.length;
+        assertBytesEq(slice(encoded, accountsOffset, 4), le32(accountCount));
+        accountsOffset += 4;
+
+        for (uint256 i; i < accountCount; ++i) {
+            bool isSigner = ((signerMask >> i) & 1) == 1;
+            bool isWritable = ((writableMask >> i) & 1) == 1;
+            uint8 flags = (isSigner ? uint8(1) : uint8(0)) | (isWritable ? uint8(2) : uint8(0));
+
+            assertBytesEq(slice(encoded, accountsOffset + i * 33, 32), abi.encodePacked(pubkeys[i]));
+            require(uint8(encoded[accountsOffset + i * 33 + 32]) == flags, "bad account flags");
+        }
+    }
+
     function testFuzzAbiEncodingRoundTrip(bytes memory executePayload, bytes32 pubkey, bool isSigner, bool isWritable)
         public
         pure
@@ -159,11 +197,23 @@ contract SolanaGatewayPayloadTest {
         );
     }
 
+    function bound(uint8 value, uint8 min, uint8 max) private pure returns (uint8) {
+        return uint8(uint256(min) + (uint256(value) % (uint256(max) - uint256(min) + 1)));
+    }
+
     function skipSchemeByte(bytes memory input) private pure returns (bytes memory output) {
         require(input.length > 0, "empty input");
         output = new bytes(input.length - 1);
         for (uint256 i; i < output.length; ++i) {
             output[i] = input[i + 1];
+        }
+    }
+
+    function slice(bytes memory input, uint256 start, uint256 length) private pure returns (bytes memory output) {
+        require(input.length >= start + length, "slice out of bounds");
+        output = new bytes(length);
+        for (uint256 i; i < length; ++i) {
+            output[i] = input[start + i];
         }
     }
 

--- a/programs/solana-axelar-gateway/src/payload/encoding.rs
+++ b/programs/solana-axelar-gateway/src/payload/encoding.rs
@@ -195,4 +195,152 @@ pub(crate) mod tests {
             );
         }
     }
+
+    #[test]
+    fn decodes_solidity_borsh_payload_fixture() {
+        let encoded = hex::decode(concat!(
+            // scheme
+            "00",
+            // execute payload length + payload
+            "03000000",
+            "010203",
+            // accounts length
+            "04000000",
+            // signer + writable
+            "0000000000000000000000000000000000000000000000000000000000001111",
+            "03",
+            // signer + readonly
+            "0000000000000000000000000000000000000000000000000000000000002222",
+            "01",
+            // non-signer + writable
+            "0000000000000000000000000000000000000000000000000000000000003333",
+            "02",
+            // non-signer + readonly
+            "0000000000000000000000000000000000000000000000000000000000004444",
+            "00",
+        ))
+        .unwrap();
+
+        assert_decodes_solidity_borsh_payload(&encoded);
+    }
+
+    #[test]
+    fn decodes_forge_generated_borsh_payload() {
+        let manifest_dir = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+        let repo_root = manifest_dir
+            .parent()
+            .and_then(std::path::Path::parent)
+            .expect("gateway crate should be under programs/");
+        let evm_contracts = repo_root.join("evm-contracts");
+
+        let output = std::process::Command::new("forge")
+            .args([
+                "test",
+                "--match-test",
+                "testEmitBorshPayloadForRustCompatibility",
+                "-vv",
+                "--json",
+            ])
+            .current_dir(evm_contracts)
+            .output();
+
+        let output = match output {
+            Ok(output) => output,
+            Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
+                eprintln!(
+                    "skipping forge-generated Solana gateway payload compatibility test: forge is not installed"
+                );
+                return;
+            }
+            Err(err) => panic!("failed to run forge: {err}"),
+        };
+
+        assert!(
+            output.status.success(),
+            "forge failed:\nstdout:\n{}\nstderr:\n{}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
+
+        let stdout = String::from_utf8(output.stdout).expect("forge stdout must be utf8");
+        let event_data = extract_first_json_hex_data(&stdout);
+        let encoded = decode_single_bytes_event_data(&event_data);
+
+        assert_decodes_solidity_borsh_payload(&encoded);
+    }
+
+    fn assert_decodes_solidity_borsh_payload(encoded: &[u8]) {
+        fn pubkey_with_suffix(suffix: [u8; 2]) -> [u8; 32] {
+            let mut pubkey = [0_u8; 32];
+            pubkey[30..].copy_from_slice(&suffix);
+            pubkey
+        }
+
+        let decoded = AxelarMessagePayload::decode(&encoded).unwrap();
+        let accounts = decoded.solana_accounts().copied().collect::<Vec<_>>();
+
+        assert_eq!(decoded.encoding_scheme(), EncodingScheme::Borsh);
+        assert_eq!(decoded.payload_without_accounts(), [1, 2, 3]);
+        assert_eq!(accounts.len(), 4);
+
+        assert_eq!(
+            accounts[0].pubkey.as_slice(),
+            pubkey_with_suffix([0x11, 0x11]).as_slice()
+        );
+        assert!(accounts[0].is_signer);
+        assert!(accounts[0].is_writable);
+
+        assert_eq!(
+            accounts[1].pubkey.as_slice(),
+            pubkey_with_suffix([0x22, 0x22]).as_slice()
+        );
+        assert!(accounts[1].is_signer);
+        assert!(!accounts[1].is_writable);
+
+        assert_eq!(
+            accounts[2].pubkey.as_slice(),
+            pubkey_with_suffix([0x33, 0x33]).as_slice()
+        );
+        assert!(!accounts[2].is_signer);
+        assert!(accounts[2].is_writable);
+
+        assert_eq!(
+            accounts[3].pubkey.as_slice(),
+            pubkey_with_suffix([0x44, 0x44]).as_slice()
+        );
+        assert!(!accounts[3].is_signer);
+        assert!(!accounts[3].is_writable);
+    }
+
+    fn extract_first_json_hex_data(json: &str) -> Vec<u8> {
+        let marker = r#""data":"0x"#;
+        let start = json.find(marker).expect("missing event data") + marker.len();
+        let end = json[start..].find('"').expect("unterminated event data") + start;
+        hex::decode(&json[start..end]).expect("event data must be hex")
+    }
+
+    fn decode_single_bytes_event_data(event_data: &[u8]) -> Vec<u8> {
+        fn read_abi_usize(word: &[u8]) -> usize {
+            assert_eq!(word.len(), 32);
+            let mut value = 0_usize;
+            for byte in &word[24..] {
+                value = (value << 8) | usize::from(*byte);
+            }
+            value
+        }
+
+        assert!(event_data.len() >= 64, "event data too short");
+        let offset = read_abi_usize(&event_data[..32]);
+        assert_eq!(offset, 32, "unexpected event data offset");
+
+        let length = read_abi_usize(&event_data[32..64]);
+        let payload_start = 64;
+        let payload_end = payload_start + length;
+        assert!(
+            event_data.len() >= payload_end,
+            "event data shorter than encoded bytes length"
+        );
+
+        event_data[payload_start..payload_end].to_vec()
+    }
 }

--- a/programs/solana-axelar-gateway/src/payload/encoding.rs
+++ b/programs/solana-axelar-gateway/src/payload/encoding.rs
@@ -226,6 +226,8 @@ pub(crate) mod tests {
 
     #[test]
     fn decodes_forge_generated_borsh_payload() {
+        use std::io::Write as _;
+
         let manifest_dir = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"));
         let repo_root = manifest_dir
             .parent()
@@ -247,12 +249,19 @@ pub(crate) mod tests {
         let output = match output {
             Ok(output) => output,
             Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
-                eprintln!(
-                    "skipping forge-generated Solana gateway payload compatibility test: forge is not installed"
+                let _ignored = std::io::stderr().write_all(
+                    b"skipping forge-generated Solana gateway payload compatibility test: forge is not installed\n",
                 );
                 return;
             }
-            Err(err) => panic!("failed to run forge: {err}"),
+            Err(err) => {
+                assert_eq!(
+                    err.kind(),
+                    std::io::ErrorKind::NotFound,
+                    "failed to run forge: {err}",
+                );
+                return;
+            }
         };
 
         assert!(
@@ -276,64 +285,80 @@ pub(crate) mod tests {
             pubkey
         }
 
-        let decoded = AxelarMessagePayload::decode(&encoded).unwrap();
+        let decoded = AxelarMessagePayload::decode(encoded).unwrap();
         let accounts = decoded.solana_accounts().copied().collect::<Vec<_>>();
 
         assert_eq!(decoded.encoding_scheme(), EncodingScheme::Borsh);
         assert_eq!(decoded.payload_without_accounts(), [1, 2, 3]);
         assert_eq!(accounts.len(), 4);
+        let account_0 = accounts.first().expect("missing account 0");
+        let account_1 = accounts.get(1).expect("missing account 1");
+        let account_2 = accounts.get(2).expect("missing account 2");
+        let account_3 = accounts.get(3).expect("missing account 3");
 
         assert_eq!(
-            accounts[0].pubkey.as_slice(),
+            account_0.pubkey.as_slice(),
             pubkey_with_suffix([0x11, 0x11]).as_slice()
         );
-        assert!(accounts[0].is_signer);
-        assert!(accounts[0].is_writable);
+        assert!(account_0.is_signer);
+        assert!(account_0.is_writable);
 
         assert_eq!(
-            accounts[1].pubkey.as_slice(),
+            account_1.pubkey.as_slice(),
             pubkey_with_suffix([0x22, 0x22]).as_slice()
         );
-        assert!(accounts[1].is_signer);
-        assert!(!accounts[1].is_writable);
+        assert!(account_1.is_signer);
+        assert!(!account_1.is_writable);
 
         assert_eq!(
-            accounts[2].pubkey.as_slice(),
+            account_2.pubkey.as_slice(),
             pubkey_with_suffix([0x33, 0x33]).as_slice()
         );
-        assert!(!accounts[2].is_signer);
-        assert!(accounts[2].is_writable);
+        assert!(!account_2.is_signer);
+        assert!(account_2.is_writable);
 
         assert_eq!(
-            accounts[3].pubkey.as_slice(),
+            account_3.pubkey.as_slice(),
             pubkey_with_suffix([0x44, 0x44]).as_slice()
         );
-        assert!(!accounts[3].is_signer);
-        assert!(!accounts[3].is_writable);
+        assert!(!account_3.is_signer);
+        assert!(!account_3.is_writable);
     }
 
     fn extract_first_json_hex_data(json: &str) -> Vec<u8> {
         let marker = r#""data":"0x"#;
         let start = json.find(marker).expect("missing event data") + marker.len();
-        let end = json[start..].find('"').expect("unterminated event data") + start;
-        hex::decode(&json[start..end]).expect("event data must be hex")
+        let json_bytes = json.as_bytes();
+        let rest = json_bytes.get(start..).expect("missing event data suffix");
+        let end = rest
+            .iter()
+            .position(|byte| *byte == b'"')
+            .expect("unterminated event data")
+            + start;
+        let hex_data = std::str::from_utf8(
+            json_bytes
+                .get(start..end)
+                .expect("missing event data slice"),
+        )
+        .expect("event data must be utf8");
+        hex::decode(hex_data).expect("event data must be hex")
     }
 
     fn decode_single_bytes_event_data(event_data: &[u8]) -> Vec<u8> {
         fn read_abi_usize(word: &[u8]) -> usize {
             assert_eq!(word.len(), 32);
             let mut value = 0_usize;
-            for byte in &word[24..] {
+            for byte in word.get(24..).expect("ABI word should have low bytes") {
                 value = (value << 8) | usize::from(*byte);
             }
             value
         }
 
         assert!(event_data.len() >= 64, "event data too short");
-        let offset = read_abi_usize(&event_data[..32]);
+        let offset = read_abi_usize(event_data.get(..32).expect("missing ABI offset"));
         assert_eq!(offset, 32, "unexpected event data offset");
 
-        let length = read_abi_usize(&event_data[32..64]);
+        let length = read_abi_usize(event_data.get(32..64).expect("missing ABI length"));
         let payload_start = 64;
         let payload_end = payload_start + length;
         assert!(
@@ -341,6 +366,9 @@ pub(crate) mod tests {
             "event data shorter than encoded bytes length"
         );
 
-        event_data[payload_start..payload_end].to_vec()
+        event_data
+            .get(payload_start..payload_end)
+            .expect("missing ABI payload")
+            .to_vec()
     }
 }


### PR DESCRIPTION
### why

creates a (minimal) helper Solidity library for making Solana gateway payloads, focusing on Borsh.

### how
<!-- An agent will fill this out -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New cross-chain encoding surface must stay byte-compatible with the Solana gateway decoder; mistakes would break ITS/contract calls to Solana, mitigated by fixture and optional Forge integration tests.
> 
> **Overview**
> Adds a new **`evm-contracts`** Foundry package with Solidity helpers so EVM callers can build Axelar Solana gateway executable bytes (Borsh-focused inner instruction helpers plus gateway envelope encoding for Borsh and ABI).
> 
> **`SolanaGatewayPayload.sol`** wraps caller-supplied `executePayload` and `SolanaAccountRepr[]` with scheme byte `0` (Borsh) or `1` (ABI), matching `programs/solana-axelar-gateway` payload layout; **`BorshEncoding.sol`** supplies minimal little-endian Borsh primitives for custom inner payloads. Docs cover ITS `callContractWithInterchainToken` / legacy metadata wrapping.
> 
> Forge unit/fuzz tests cover encoding; the gateway crate gains Rust tests that decode a fixed hex fixture and optionally run Forge to verify live Solidity output. **`.gitignore`** ignores `evm-contracts/out` and `cache`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 50b9b56d2c1d501811c0d850087fdb3f405ddf2b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->