### PR TITLE
chore(solana-axelar-gateway): update outdated comments

### DIFF
--- a/programs/solana-axelar-gateway/src/payload/mod.rs
+++ b/programs/solana-axelar-gateway/src/payload/mod.rs
@@ -10,22 +10,22 @@ mod encoding;
 pub use accounts::SolanaAccountRepr;
 pub use encoding::EncodingScheme;
 
-/// In standard Axelar flow, the accounts are concatenated at the beginning of
-/// the payload message. This struct represents a Solana account in a way that
+/// In standard Axelar flow, the accounts are concatenated at the end of the
+/// payload message. This struct represents a Solana account in a way that
 /// can be easily serialized and deserialized.
 ///
 /// The payload is encoded in the following way:
 /// - the first byte is encoding scheme, encoded as an u8.
-/// - the rest of the data is encoded([account array][payload bytes]). The
+/// - the rest of the data is encoded([payload bytes][account array]). The
 ///   encoding depends on the encoding scheme.
 ///
 /// ```text
-/// [u8 scheme] encoded([account array][payload bytes])
+/// [u8 scheme] encoded([payload bytes][account array])
 /// ```
 #[derive(PartialEq, Debug, Eq, Clone)]
 pub struct AxelarMessagePayload<'payload> {
-    // Using Cow because on-chain we will use a the owned version (because of the decoding),
-    // but off-chain we will use the borrowed version to prevent unnecessary cloning.
+    // Using a borrowed slice so on-chain decoding can return a zero-copy reference
+    // into the instruction data, and off-chain construction can borrow without cloning.
     payload_without_accounts: &'payload [u8],
     solana_accounts: Vec<SolanaAccountRepr>,
     encoding_scheme: EncodingScheme,


### PR DESCRIPTION
### why
- <!-- Explain the reason for this change -->

### how
<!-- An agent will fill this out -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Comment-only changes with no runtime or encoding behavior modifications.
> 
> **Overview**
> Updates **documentation only** in `programs/solana-axelar-gateway/src/payload/mod.rs` for `AxelarMessagePayload` so it matches the real wire layout: Solana accounts are described as appended **after** the payload bytes (`[payload bytes][account array]`), not before.
> 
> Also refreshes the `Cow` vs borrowed-slice comment on the struct field to explain on-chain zero-copy decoding from instruction data and off-chain borrowing without cloning.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9a325de31e8a0761f1654db4f6c1812d7549a612. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->