### PR TITLE
chore: fix ruint to 1.16

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1813,6 +1813,7 @@ dependencies = [
  "alloy-primitives",
  "alloy-sol-types",
  "hex",
+ "ruint",
 ]
 
 [[package]]
@@ -3448,6 +3449,7 @@ dependencies = [
  "num-derive 0.4.2",
  "num-traits",
  "rand 0.8.6",
+ "ruint",
  "solana-axelar-std",
  "solana-keccak-hasher",
  "solana-sdk",
@@ -3573,6 +3575,7 @@ dependencies = [
  "hex",
  "rand 0.8.6",
  "rs_merkle",
+ "ruint",
  "solana-keccak-hasher",
  "thiserror 1.0.69",
  "udigest",

--- a/crates/governance-gmp/Cargo.toml
+++ b/crates/governance-gmp/Cargo.toml
@@ -6,7 +6,14 @@ description = "Governance GMP message encoding and decoding for Axelar"
 license.workspace = true
 repository.workspace = true
 
+[package.metadata.cargo-machete]
+# `ruint` is intentionally unused directly. It constrains Alloy's transitive
+# dependency during `cargo publish`, where the workspace lockfile is ignored.
+ignored = ["ruint"]
+
 [dependencies]
 alloy-primitives.workspace = true
 alloy-sol-types.workspace = true
 hex.workspace = true
+# Keep Alloy's transitive `ruint` on the workspace-pinned SBF-compatible version.
+ruint.workspace = true

--- a/crates/solana-axelar-std/Cargo.toml
+++ b/crates/solana-axelar-std/Cargo.toml
@@ -9,6 +9,11 @@ repository.workspace = true
 [lints]
 workspace = true
 
+[package.metadata.cargo-machete]
+# `ruint` is intentionally unused directly. It constrains Alloy's transitive
+# dependency during `cargo publish`, where the workspace lockfile is ignored.
+ignored = ["ruint"]
+
 [dependencies]
 alloy-primitives.workspace = true
 arrayref.workspace = true
@@ -21,6 +26,8 @@ anchor-lang = { workspace = true, optional = true }
 solana-keccak-hasher.workspace = true
 bytemuck.workspace = true
 bnum.workspace = true
+# Keep Alloy's transitive `ruint` on the workspace-pinned SBF-compatible version.
+ruint.workspace = true
 
 [dev-dependencies]
 rand.workspace = true

--- a/programs/solana-axelar-gateway/Cargo.toml
+++ b/programs/solana-axelar-gateway/Cargo.toml
@@ -8,6 +8,11 @@ license.workspace = true
 edition.workspace = true
 description = "Axelar Gateway Anchor program for Solana"
 
+[package.metadata.cargo-machete]
+# `ruint` is intentionally unused directly. It constrains Alloy's transitive
+# dependency during `cargo publish`, where the workspace lockfile is ignored.
+ignored = ["ruint"]
+
 [dependencies]
 bytemuck.workspace = true
 anchor-lang.workspace = true
@@ -21,6 +26,8 @@ alloy-primitives.workspace = true
 alloy-sol-types.workspace = true
 num-derive.workspace = true
 num-traits.workspace = true
+# Keep Alloy's transitive `ruint` on the workspace-pinned SBF-compatible version.
+ruint.workspace = true
 
 [dev-dependencies]
 mollusk-harness.workspace = true


### PR DESCRIPTION
### why

`cargo publish` pulls up 1.18 which fails because it needs rustc 1.90.

https://github.com/axelarnetwork/axelar-amplifier-solana/actions/runs/26578860078

### how
<!-- An agent will fill this out -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependency-only change with no runtime logic; lowers publish/CI risk from an incompatible transitive `ruint` upgrade.
> 
> **Overview**
> Adds an explicit workspace **`ruint`** dependency to **`governance-gmp`**, **`solana-axelar-std`**, and **`solana-axelar-gateway`** (all Alloy consumers) so **`cargo publish`** still resolves **`ruint` 1.16** instead of pulling **1.18**, which breaks the Solana/SBF toolchain (needs newer rustc). Each crate documents that the dep is a version constraint, not direct usage, and marks **`ruint`** as ignored in **cargo-machete**. **`Cargo.lock`** is updated accordingly.
> 
> No program or library source behavior changes—only manifest and lockfile wiring for publish/CI.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2971d3de017841eca1acaa8af69fd34f9c4e16e2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->